### PR TITLE
Enable nearby restaurant search

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -135,6 +135,7 @@ Create a `.env.local` file in the `frontend` directory. Add your MongoDB connect
 ```dotenv
 MONGODB_URI=your_mongodb_connection_string
 JWT_SECRET=your_very_strong_and_secret_key_here
+GOOGLE_PLACES_API_KEY=your_google_places_api_key
 ```
 
 ## Testing
@@ -148,6 +149,7 @@ End-to-end tests are configured in `playwright.config.js` and can be run with:
 ```bash
 npm run test:playwright
 ```
+This command automatically installs Playwright browsers if they haven't been installed.
 
 ### Component Testing
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test:playwright": "playwright test",
+    "test:playwright": "node scripts/run-playwright.mjs",
     "test:components": "cross-env NODE_ENV=test-ct playwright test --config=playwright-ct.config.js",
     "seed": "node src/lib/HiGHS/seed_database.mjs",
     "codegen": "graphql-codegen --config codegen.yml"

--- a/frontend/scripts/run-playwright.mjs
+++ b/frontend/scripts/run-playwright.mjs
@@ -1,0 +1,15 @@
+import { execSync } from 'child_process';
+
+function run(cmd) {
+  execSync(cmd, { stdio: 'inherit', shell: true });
+}
+
+try {
+  // Install browsers if they haven't been installed
+  run('npx playwright install');
+  // Run Playwright tests
+  run('npx playwright test');
+} catch (err) {
+  console.error('Playwright tests failed:', err);
+  process.exit(1);
+}

--- a/frontend/src/components/Dashboard/RestaurantCard.js
+++ b/frontend/src/components/Dashboard/RestaurantCard.js
@@ -10,10 +10,20 @@ export default function RestaurantCard({ restaurant }) {
       elevation={0}
       sx={{ borderColor:'surface.light', borderWidth:1, borderStyle:'solid', borderRadius:2, mt:1 }}
     >
-      <CardMedia component="img" height="100" image={restaurant.imageUrl} alt={restaurant.name} />
+      <CardMedia
+        component="img"
+        height="100"
+        image={restaurant.imageUrl || '/favicon.ico'}
+        alt={restaurant.name}
+      />
       <CardContent>
         <Typography variant="subtitle1" fontWeight={600}>{restaurant.name}</Typography>
-        <Typography variant="body2" color="text.secondary">{restaurant.cuisine}</Typography>
+        {restaurant.vicinity && (
+          <Typography variant="body2" color="text.secondary">{restaurant.vicinity}</Typography>
+        )}
+        {restaurant.rating && (
+          <Typography variant="body2" color="text.secondary">Rating: {restaurant.rating}</Typography>
+        )}
       </CardContent>
     </Card>
   );

--- a/frontend/src/graphql/resolvers/queries/restaurantQueries.js
+++ b/frontend/src/graphql/resolvers/queries/restaurantQueries.js
@@ -42,3 +42,20 @@ export const searchRestaurants = withErrorHandling(async (_parent, { keyword }, 
     restaurantName: { $regex: keyword, $options: 'i' }
   });
 });
+/**
+ * Finds nearby restaurants using the Google Places API.
+ *
+ * @function findNearbyRestaurants
+ * @param {object} _parent
+ * @param {object} args - { latitude, longitude, radius, keyword }
+ * @param {object} context - GraphQL context
+ * @returns {Promise<Object[]>} Array of ExternalRestaurant objects
+ */
+export const findNearbyRestaurants = withErrorHandling(async (
+  _parent,
+  { latitude, longitude, radius, keyword },
+  context
+) => {
+  const service = await import('@/services/places.service.js');
+  return service.findNearbyRestaurants(latitude, longitude, radius, keyword);
+});

--- a/frontend/src/services/places.service.js
+++ b/frontend/src/services/places.service.js
@@ -1,0 +1,33 @@
+export async function findNearbyRestaurants(latitude, longitude, radius = 1000, keyword = '') {
+  const apiKey = process.env.GOOGLE_PLACES_API_KEY;
+  if (!apiKey) {
+    throw new Error('GOOGLE_PLACES_API_KEY is not defined');
+  }
+
+  const params = new URLSearchParams({
+    location: `${latitude},${longitude}`,
+    radius: String(radius),
+    type: 'restaurant',
+    key: apiKey
+  });
+  if (keyword) params.set('keyword', keyword);
+
+  const url = `https://maps.googleapis.com/maps/api/place/nearbysearch/json?${params.toString()}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Google Places API error: ${res.status}`);
+  }
+  const data = await res.json();
+  if (!Array.isArray(data.results)) return [];
+  return data.results.map((place) => ({
+    placeId: place.place_id,
+    name: place.name,
+    vicinity: place.vicinity,
+    rating: place.rating,
+    userRatingsTotal: place.user_ratings_total,
+    location: {
+      latitude: place.geometry?.location?.lat ?? null,
+      longitude: place.geometry?.location?.lng ?? null,
+    },
+  }));
+}


### PR DESCRIPTION
## Summary
- integrate Google Places API via new `findNearbyRestaurants` service
- expose `findNearbyRestaurants` in GraphQL queries
- load nearby restaurants on dashboard using geolocation
- show basic restaurant info even when images are missing
- document `GOOGLE_PLACES_API_KEY` env variable
- add `scripts/run-playwright.mjs` to install browsers and run tests

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test:playwright` *(fails: unable to fetch Playwright package)*