### PR TITLE
Add dashboard link to profile

### DIFF
--- a/frontend/src/components/Dashboard/NewHeader.js
+++ b/frontend/src/components/Dashboard/NewHeader.js
@@ -5,9 +5,11 @@ import React from 'react';
 import { AppBar, Toolbar, IconButton, Avatar, Typography } from '@mui/material';
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 import { useDashStore } from './store';
+import { useRouter } from 'next/router';
 
 export default function NewHeader({ user }) {
   const toggleDrawer = useDashStore(s => s.toggleDrawer);
+  const router = useRouter();
   return (
     <AppBar elevation={0} sx={{ bgcolor:'primary.main', px:2 }}>
       <Toolbar disableGutters sx={{ justifyContent:'space-between' }}>
@@ -15,7 +17,17 @@ export default function NewHeader({ user }) {
           <MenuRoundedIcon />
         </IconButton>
         <Typography variant="h6" fontWeight={600}>Fine Dining</Typography>
-        <Avatar alt={user?.name} src={user?.avatarUrl} sx={{ width:36, height:36 }} />
+        <IconButton
+          color="inherit"
+          onClick={() => router.push('/profile')}
+          title="Profile"
+        >
+          <Avatar
+            alt={user?.name}
+            src={user?.avatarUrl}
+            sx={{ width:36, height:36 }}
+          />
+        </IconButton>
       </Toolbar>
     </AppBar>
   );

--- a/frontend/src/tests/components/NewHeader.spec.js
+++ b/frontend/src/tests/components/NewHeader.spec.js
@@ -20,9 +20,9 @@ test.describe('NewHeader Component', () => {
     // Check if the component renders the company name
     await expect(component.getByText('Fine Dining')).toBeVisible();
 
-    // Check if the avatar is rendered
-    const avatar = component.locator('img[alt="Test User"]');
-    await expect(avatar).toBeVisible();
+    // Check if the avatar button is rendered
+    const buttons = component.locator('button');
+    await expect(buttons.nth(1)).toBeVisible();
   });
 
   test('toggles drawer when menu button is clicked', async ({ mount }) => {
@@ -37,6 +37,15 @@ test.describe('NewHeader Component', () => {
     await menuButton.click();
 
     // We can only verify the button was clicked, not that the function was called
+  });
+
+  test('profile button is clickable', async ({ mount }) => {
+    const component = await mount(<NewHeader user={mockUser} />);
+
+    const profileButton = component.locator('button').nth(1);
+    await expect(profileButton).toBeVisible();
+    await expect(profileButton).toBeEnabled();
+    await profileButton.click();
   });
 
   test('renders without user data', async ({ mount }) => {


### PR DESCRIPTION
## Summary
- make the dashboard header avatar a button that routes to `/profile`
- update NewHeader component tests for the new profile button

## Testing
- `npm run lint` *(fails: `next` not found)*