### PR TITLE
Add presolve routines and GraphQL query

### DIFF
--- a/frontend/src/graphql/resolvers/queries/generalQueries.js
+++ b/frontend/src/graphql/resolvers/queries/generalQueries.js
@@ -1,4 +1,6 @@
 import { withErrorHandling } from './baseQueries.js';
+import { run as presolve } from '@/lib/HiGHS/src/presolve/index.mjs';
+import { readMeals, buildMealPlanModel } from '@/lib/HiGHS/src/solver/index.mjs';
 
 /**
  * Basic health check query.
@@ -7,3 +9,16 @@ import { withErrorHandling } from './baseQueries.js';
  * @returns {string} "pong"
  */
 export const ping = withErrorHandling(() => 'pong');
+
+/**
+ * Returns variable counts before and after presolve.
+ */
+export const presolveStats = withErrorHandling(async () => {
+    const data = await readMeals();
+    const baseModel = buildMealPlanModel(data);
+    const presolved = presolve(baseModel);
+    return {
+        before: baseModel.columnCount,
+        after: presolved.columnCount,
+    };
+});

--- a/frontend/src/graphql/typeDefs.js
+++ b/frontend/src/graphql/typeDefs.js
@@ -341,6 +341,14 @@ export const typeDefs = gql`
     }
 
     """
+    Statistics on presolve reduction.
+    """
+    type PresolveStats {
+        before: Int!
+        after: Int!
+    }
+
+    """
     Represents nutritional and activity statistics logged by a user.
     """
     type Stats {
@@ -401,6 +409,7 @@ export const typeDefs = gql`
     """
     type Query {
         ping: String
+        presolveStats: PresolveStats
         getUser(id: ID!): User
         getUsers(page: Int, limit: Int): [User]
         searchUsers(keyword: String!): [User]

--- a/frontend/src/lib/HiGHS/package.json
+++ b/frontend/src/lib/HiGHS/package.json
@@ -8,7 +8,8 @@
     "start": "node src/main_pipeline.mjs",
     "setup": "node setup_pipeline.mjs",
     "build-csv": "node tools/build-meal-csv.mjs",
-    "solve": "node src/solver/index.mjs"
+    "solve": "node src/solver/index.mjs",
+    "benchmark:presolve": "node src/presolve/benchmark.mjs"
   },
   "author": "",
   "license": "ISC",

--- a/frontend/src/lib/HiGHS/src/presolve/benchmark.mjs
+++ b/frontend/src/lib/HiGHS/src/presolve/benchmark.mjs
@@ -1,0 +1,18 @@
+import { readMeals, buildMealPlanModel } from '../solver/index.mjs';
+import { run as presolve } from './index.mjs';
+
+async function benchmark() {
+    const data = await readMeals();
+    const baseModel = buildMealPlanModel(data);
+    const baseCols = baseModel.columnCount;
+
+    const presolved = presolve(baseModel);
+    const presCols = presolved.columnCount;
+
+    console.log(`Variables before presolve: ${baseCols}`);
+    console.log(`Variables after presolve : ${presCols}`);
+}
+
+benchmark().catch(err => {
+    console.error('Benchmark failed:', err);
+});

--- a/frontend/src/lib/HiGHS/src/presolve/boundTightening.mjs
+++ b/frontend/src/lib/HiGHS/src/presolve/boundTightening.mjs
@@ -1,0 +1,31 @@
+export function boundTightening(model) {
+    const { columnCount, rowCount, rowLowerBounds, rowUpperBounds } = model;
+    const { offsets, values } = model.weights;
+
+    const newLower = model.columnLowerBounds.slice();
+    const newUpper = model.columnUpperBounds.slice();
+
+    for (let j = 0; j < columnCount; ++j) {
+        for (let i = 0; i < rowCount; ++i) {
+            const coeff = values[offsets[i] + j];
+            if (coeff <= 0) continue;
+            const maxUb = rowUpperBounds[i] / coeff;
+            if (maxUb < newUpper[j]) {
+                newUpper[j] = maxUb;
+            }
+            const minLb = rowLowerBounds[i] / coeff;
+            if (minLb > newLower[j]) {
+                newLower[j] = minLb;
+            }
+        }
+        if (newLower[j] > newUpper[j]) {
+            newLower[j] = newUpper[j];
+        }
+    }
+
+    return {
+        ...model,
+        columnLowerBounds: newLower,
+        columnUpperBounds: newUpper,
+    };
+}

--- a/frontend/src/lib/HiGHS/src/presolve/coefficientAggregation.mjs
+++ b/frontend/src/lib/HiGHS/src/presolve/coefficientAggregation.mjs
@@ -1,0 +1,58 @@
+export function coefficientAggregation(model) {
+    const { columnCount, rowCount } = model;
+    const { offsets, indices, values } = model.weights;
+
+    const map = new Map();
+    const keep = [];
+    const colMap = new Array(columnCount).fill(-1);
+
+    for (let j = 0; j < columnCount; ++j) {
+        const keyParts = [];
+        for (let i = 0; i < rowCount; ++i) {
+            keyParts.push(values[offsets[i] + j]);
+        }
+        const key = keyParts.join(',');
+        if (map.has(key)) {
+            const k = map.get(key);
+            model.columnUpperBounds[k] += model.columnUpperBounds[j];
+            model.columnLowerBounds[k] += model.columnLowerBounds[j];
+        } else {
+            const k = keep.length;
+            map.set(key, k);
+            keep.push(j);
+            colMap[j] = k;
+        }
+    }
+
+    const newColumnCount = keep.length;
+    const newUpper = new Float64Array(newColumnCount);
+    const newLower = new Float64Array(newColumnCount);
+    const newIndices = new Int32Array(rowCount * newColumnCount);
+    const newValues = new Float64Array(rowCount * newColumnCount);
+    const newOffsets = new Int32Array(rowCount + 1);
+
+    for (let idx = 0; idx < keep.length; ++idx) {
+        const orig = keep[idx];
+        newUpper[idx] = model.columnUpperBounds[orig];
+        newLower[idx] = model.columnLowerBounds[orig];
+        for (let i = 0; i < rowCount; ++i) {
+            newIndices[i * newColumnCount + idx] = idx;
+            newValues[i * newColumnCount + idx] = values[offsets[i] + orig];
+        }
+    }
+    for (let i = 0; i <= rowCount; ++i) {
+        newOffsets[i] = i * newColumnCount;
+    }
+
+    return {
+        ...model,
+        columnCount: newColumnCount,
+        columnUpperBounds: newUpper,
+        columnLowerBounds: newLower,
+        weights: {
+            offsets: newOffsets,
+            indices: newIndices,
+            values: newValues,
+        },
+    };
+}

--- a/frontend/src/lib/HiGHS/src/presolve/index.mjs
+++ b/frontend/src/lib/HiGHS/src/presolve/index.mjs
@@ -1,0 +1,10 @@
+import { boundTightening } from './boundTightening.mjs';
+import { coefficientAggregation } from './coefficientAggregation.mjs';
+
+export function run(model) {
+    let result = boundTightening(model);
+    result = coefficientAggregation(result);
+    return result;
+}
+
+export { boundTightening, coefficientAggregation };

--- a/frontend/src/lib/HiGHS/src/solver/index.mjs
+++ b/frontend/src/lib/HiGHS/src/solver/index.mjs
@@ -183,7 +183,11 @@ async function main() {
     });
 }
 
-main().catch(e => {
-    console.error('❌ Unexpected failure:', e);
-    process.exit(1);
-});
+export { readMeals, buildMealPlanModel, main };
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main().catch(e => {
+        console.error('❌ Unexpected failure:', e);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
## Summary
- add bound tightening and coefficient aggregation routines
- provide presolve pipeline entry point and benchmark script
- expose presolve stats via GraphQL and update schema
- export solver helpers for reuse
- add benchmark npm script

## Testing
- `npm --prefix frontend run lint` *(fails: next not found)*