### PR TITLE
Add standardized solver error handling

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,17 @@
+# Troubleshooting Solver Errors
+
+This document lists common issues encountered when running the HiGHS solver and how to resolve them.
+
+## Error Codes
+
+| Code | Meaning |
+|------|---------|
+| `E_SOLVER_INFEASIBLE` | No feasible solution exists for the provided constraints. Consider loosening nutritional targets or ensuring the meal data is complete. |
+| `E_SOLVER_NUMERICAL` | The solver failed due to numerical instability. Check your input data for extreme or inconsistent values. |
+| `E_SOLVER_UNKNOWN` | The solver ended with an unexpected status. Review logs for additional details. |
+
+## Typical Fixes
+
+- **Infeasible models**: Try widening the calorie or macro ranges in your request. Ensure there are enough meals with valid nutrition data.
+- **Numerical issues**: Inspect the meal dataset for very large or very small numbers. Removing outliers often resolves this problem.
+- **Unknown status**: Ensure you are using a compatible version of the HiGHS addon and that all inputs are valid.

--- a/frontend/src/io/solverOutput.js
+++ b/frontend/src/io/solverOutput.js
@@ -1,0 +1,32 @@
+export const SolverErrorCodes = {
+  INFEASIBLE: 'E_SOLVER_INFEASIBLE',
+  NUMERICAL: 'E_SOLVER_NUMERICAL',
+  UNKNOWN: 'E_SOLVER_UNKNOWN'
+};
+
+export function interpretStatus(status) {
+  switch (status) {
+    case 8:
+      return {
+        code: SolverErrorCodes.INFEASIBLE,
+        message: 'No feasible solution found. Try relaxing constraints or check input data.'
+      };
+    case 13:
+      return {
+        code: SolverErrorCodes.NUMERICAL,
+        message: 'Solver encountered numerical instability. Check data for extreme or inconsistent values.'
+      };
+    default:
+      return {
+        code: SolverErrorCodes.UNKNOWN,
+        message: `Solver terminated with status code ${status}.`
+      };
+  }
+}
+
+export function createSolverError(status) {
+  const { code, message } = interpretStatus(status);
+  const err = new Error(message);
+  err.code = code;
+  return err;
+}

--- a/frontend/src/lib/HiGHS/src/solver/index.mjs
+++ b/frontend/src/lib/HiGHS/src/solver/index.mjs
@@ -15,6 +15,7 @@ import fs              from 'fs';
 import { parse }       from 'csv-parse';
 import path            from 'path';
 import { fileURLToPath } from 'url';
+import { interpretStatus } from '../../../../io/solverOutput.js';
 
 const { Solver, solverVersion } = highsDefault;
 const STATUS_OPTIMAL = 7; // HiGHS status code for Optimal
@@ -149,7 +150,8 @@ async function main() {
         const status = solver.getModelStatus();
         console.log(`📊 Solver status code: ${status}`);
         if (status !== STATUS_OPTIMAL) {
-            console.warn(`⚠️ Solver did not reach Optimal (code ${status}).`);
+            const { message } = interpretStatus(status);
+            console.warn(`⚠ ${message}`);
         }
 
         const info = solver.getInfo();

--- a/frontend/src/services/OptimizationService.js
+++ b/frontend/src/services/OptimizationService.js
@@ -11,6 +11,7 @@
 import highsDefault from 'highs-addon';
 import { MealModel } from '@/models/Meal/index.js';
 import User from '@/models/User/index.js';
+import { createSolverError } from '../io/solverOutput.js';
 
 const { Solver, solverVersion } = highsDefault;
 const STATUS_OPTIMAL = 7; // HiGHS status code for Optimal
@@ -274,11 +275,7 @@ export async function runOptimization(data) {
         console.log(`Solver status code: ${status}`);
 
         if (status !== STATUS_OPTIMAL) {
-          if (status === 8) { // Infeasible
-            return reject(new Error('No feasible meal plan found with the given constraints. Try relaxing your nutritional targets.'));
-          } else {
-            return reject(new Error(`Solver did not reach Optimal solution (status code: ${status})`));
-          }
+          return reject(createSolverError(status));
         }
 
         const info = solver.getInfo();


### PR DESCRIPTION
## Summary
- add helper to interpret solver status codes
- surface helpful solver messages when status is non-optimal
- use standardized solver errors in OptimizationService
- document common solver issues

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm run test:components` *(fails: `cross-env: not found`)*