### PR TITLE
Add plugin registry and build script

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,63 @@
+# Plugin Architecture
+
+Fine Dining supports optional solver extensions that can be loaded at runtime. Plugins live in the top-level `plugins/` directory and expose a setup function used by the solver.
+
+## Registration API
+
+Use the utilities exported from `plugins/registry.mjs`:
+
+```javascript
+import { registerPlugin, listPlugins } from '../plugins/registry.mjs';
+
+registerPlugin('myPlugin', solver => {
+  // customise solver instance
+});
+
+console.log(listPlugins()); // ['myPlugin']
+```
+
+The `registerPlugin(name, setup)` function accepts a unique plugin name and a callback. When the solver starts, each registered plugin is invoked with the solver instance allowing it to modify options, register callbacks or collect metrics.
+
+## Using Plugins in the Solver
+
+`OptimizationService` automatically loads all registered plugins. Create and register your plugins before calling any solver methods:
+
+```javascript
+import { registerPlugin } from '../plugins/registry.mjs';
+import OptimizationService from './src/services/OptimizationService.js';
+
+registerPlugin('logger', solver => {
+  solver.setOptionValue('log_to_console', true);
+});
+```
+
+The solver will call your plugin during initialisation.
+
+## Building Plugins
+
+Optional plugins may contain their own `package.json` and build steps. Run the following command to compile all plugins individually:
+
+```bash
+npm run build:plugins
+```
+
+The script looks for packages inside `plugins/` and executes `npm install` and `npm run build` if available.
+
+## Example Plugin Structure
+
+```
+plugins/
+└── logger/
+    ├── package.json
+    └── index.js
+```
+
+`index.js` should register the plugin when loaded:
+
+```javascript
+import { registerPlugin } from '../registry.mjs';
+
+registerPlugin('logger', solver => {
+  solver.setOptionValue('log_to_console', true);
+});
+```

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "build:plugins": "node scripts/build-plugins.mjs",
     "start": "next start",
     "lint": "next lint",
     "test:playwright": "node scripts/run-playwright.mjs",

--- a/frontend/scripts/build-plugins.mjs
+++ b/frontend/scripts/build-plugins.mjs
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import { spawnSync } from 'child_process';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const pluginsDir = path.resolve(__dirname, '../../plugins');
+
+if (!fs.existsSync(pluginsDir)) {
+  console.log('No plugins directory found.');
+  process.exit(0);
+}
+
+for (const dirent of fs.readdirSync(pluginsDir, { withFileTypes: true })) {
+  if (!dirent.isDirectory()) continue;
+  const pluginPath = path.join(pluginsDir, dirent.name);
+  const pkgPath = path.join(pluginPath, 'package.json');
+  if (!fs.existsSync(pkgPath)) continue;
+  console.log(`Building plugin ${dirent.name}...`);
+  spawnSync('npm', ['install', '--production'], { cwd: pluginPath, stdio: 'inherit' });
+  const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  if (pkg.scripts && pkg.scripts.build) {
+    const res = spawnSync('npm', ['run', 'build'], { cwd: pluginPath, stdio: 'inherit' });
+    if (res.status !== 0) process.exit(res.status);
+  }
+}

--- a/frontend/src/services/OptimizationService.js
+++ b/frontend/src/services/OptimizationService.js
@@ -11,6 +11,7 @@
 import highsDefault from 'highs-addon';
 import { MealModel } from '@/models/Meal/index.js';
 import User from '@/models/User/index.js';
+import { applyPlugins } from '../../../plugins/registry.mjs';
 
 const { Solver, solverVersion } = highsDefault;
 const STATUS_OPTIMAL = 7; // HiGHS status code for Optimal
@@ -260,6 +261,8 @@ export async function runOptimization(data) {
       if (HIGHS_THREADS) solver.setOptionValue('threads', parseInt(HIGHS_THREADS, 10));
       if (HIGHS_PRESOLVE) solver.setOptionValue('presolve', HIGHS_PRESOLVE);
       if (HIGHS_TIME_LIMIT) solver.setOptionValue('time_limit', parseFloat(HIGHS_TIME_LIMIT));
+      // Invoke optional plugins to modify the solver
+      applyPlugins(solver);
       solver.passModel(model);
       console.log('Model transferred to HiGHS – solving...');
 

--- a/plugins/registry.mjs
+++ b/plugins/registry.mjs
@@ -1,0 +1,41 @@
+// Simple plugin registry for solver extensions
+const registry = new Map();
+
+/**
+ * Register a solver plugin.
+ * @param {string} name - Unique plugin identifier
+ * @param {(solver: any) => void} setup - Setup function invoked with the solver instance
+ */
+export function registerPlugin(name, setup) {
+  if (registry.has(name)) {
+    throw new Error(`Plugin '${name}' already registered`);
+  }
+  registry.set(name, setup);
+}
+
+/**
+ * Get a previously registered plugin setup function.
+ * @param {string} name
+ * @returns {(solver: any) => void | undefined}
+ */
+export function getPlugin(name) {
+  return registry.get(name);
+}
+
+/**
+ * Apply all registered plugins to the target solver instance.
+ * @param {any} solver
+ */
+export function applyPlugins(solver) {
+  for (const setup of registry.values()) {
+    setup(solver);
+  }
+}
+
+/**
+ * List registered plugin names.
+ * @returns {string[]}
+ */
+export function listPlugins() {
+  return Array.from(registry.keys());
+}


### PR DESCRIPTION
## Summary
- introduce `plugins/` registry for solver extension hooks
- document plugin APIs and usage
- build plugins separately via new script
- apply registered plugins inside `OptimizationService`

## Testing
- `npm run lint` *(fails: `next` not found)*