### PR TITLE
Ensure Overpass defaults without env file

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The application includes various code implementations, such as:
 
 ### Environment Variables
 
-Create a `.env.local` file in the `frontend` directory with your database connection string and secrets:
+Create a `.env.local` file in the `frontend` directory with your database connection string and secrets. `OVERPASS_URL` is optional and defaults to the public Overpass endpoint if omitted:
 
 ```dotenv
 MONGODB_URI=your_mongodb_connection_string
@@ -109,9 +109,9 @@ Example (search for pizza within 1.5 km of New York City):
 node scripts/overpass-demo.mjs 40.7128 -74.0060 1500 pizza
 ```
 
-The script relies on `OVERPASS_URL` from your `.env.local` file (defaults to
-`https://overpass-api.de/api/interpreter`) and prints the resulting restaurant
-list as JSON.
+The script uses `OVERPASS_URL` if provided in `.env.local` but falls back to the
+standard endpoint `https://overpass-api.de/api/interpreter` when no `.env`
+file is present, printing the resulting restaurant list as JSON.
 
 **Development (Frontend):**
 * Run the Next.js development server: `npm run dev`

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -23,6 +23,7 @@ This tutorial walks you through setting up **Fine Dining** for local development
    MONGODB_URI=your_mongodb_connection
    JWT_SECRET=your_secret
    GOOGLE_PLACES_API_KEY=
+   # Optional custom Overpass endpoint (defaults to the public API if omitted)
    OVERPASS_URL=https://overpass-api.de/api/interpreter
    ```
 4. Seed the database and generate GraphQL types:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -145,10 +145,11 @@ MONGODB_URI=your_mongodb_connection_string
 JWT_SECRET=your_very_strong_and_secret_key_here
 GOOGLE_PLACES_API_KEY=your_google_places_api_key
 # Optional custom Overpass endpoint used when Google Places fails
+# Defaults to https://overpass-api.de/api/interpreter when omitted
 OVERPASS_URL=https://overpass-api.de/api/interpreter
 ```
 
-If `GOOGLE_PLACES_API_KEY` is missing or a request fails, the service falls back to OpenStreetMap Overpass. Results may be less complete and lack ratings.
+If `GOOGLE_PLACES_API_KEY` is missing or a request fails, the service falls back to OpenStreetMap Overpass. Results may be less complete and lack ratings. If no `.env.local` file is present, the default Overpass endpoint is used automatically.
 
 ## Testing
 

--- a/frontend/scripts/overpass-demo.mjs
+++ b/frontend/scripts/overpass-demo.mjs
@@ -19,7 +19,9 @@ const lat = parseFloat(latArg);
 const lon = parseFloat(lonArg);
 const radius = parseInt(radiusArg, 10);
 
-const provider = new OverpassProvider(process.env.OVERPASS_URL);
+const provider = new OverpassProvider(
+  process.env.OVERPASS_URL || 'https://overpass-api.de/api/interpreter'
+);
 
 provider.findNearby(lat, lon, radius, keyword)
   .then((restaurants) => {

--- a/frontend/src/services/places.service.js
+++ b/frontend/src/services/places.service.js
@@ -2,7 +2,9 @@ import { GooglePlacesProvider } from './providers/GooglePlacesProvider.js';
 import { OverpassProvider } from './providers/OverpassProvider.js';
 
 const google = new GooglePlacesProvider(process.env.GOOGLE_PLACES_API_KEY);
-const overpass = new OverpassProvider(process.env.OVERPASS_URL);
+const overpass = new OverpassProvider(
+  process.env.OVERPASS_URL || 'https://overpass-api.de/api/interpreter'
+);
 
 export async function findNearbyRestaurants(lat, lon, radius = 1000, keyword = '') {
   if (google.isValidKey()) {


### PR DESCRIPTION
## Summary
- default Overpass URL when env vars are missing
- document automatic fallback to Overpass API

## Testing
- `npm run test:solver` *(fails: Cannot find package 'highs-addon')*