### PR TITLE
Sanitize HTML in GraphQL mutations

### DIFF
--- a/frontend/src/graphql/resolvers/mutations/authMutations.js
+++ b/frontend/src/graphql/resolvers/mutations/authMutations.js
@@ -2,6 +2,7 @@ import { withErrorHandling } from './baseImports.js';
 import User from '@/models/User/index.js';
 import bcrypt from 'bcrypt';
 import jwt from 'jsonwebtoken';
+import { sanitizeString } from '@/lib/sanitize.js';
 
 /**
  * Logs in a user by verifying credentials.
@@ -22,7 +23,8 @@ export const loginUser = withErrorHandling(async (_parent, { email, password }, 
     if (!email || !password) {
         throw new Error('Email and password are required.');
     }
-    email = email.trim().toLowerCase();
+    email = sanitizeString(email.trim().toLowerCase());
+    const sanitizedPassword = sanitizeString(password);
 
     // Validate email format (basic regex)
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -43,7 +45,7 @@ export const loginUser = withErrorHandling(async (_parent, { email, password }, 
     }
 
     // Compare the provided password with the stored hashed password.
-    const valid = await bcrypt.compare(password, user.password);
+    const valid = await bcrypt.compare(sanitizedPassword, user.password);
     if (!valid) {
         await new Promise(resolve => setTimeout(resolve, 100)); // 500ms delay
         throw new Error('Invalid credentials');
@@ -98,7 +100,7 @@ export const requestPasswordReset = withErrorHandling(async (_parent, { email },
     }
 
     // Normalize email input.
-    const normalizedEmail = email.trim().toLowerCase();
+    const normalizedEmail = sanitizeString(email.trim().toLowerCase());
 
     // Validate the email format.
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -164,7 +166,7 @@ export const resetPassword = withErrorHandling(async (_parent, { resetToken, new
     }
 
     // Optionally sanitize newPassword (e.g., trim spaces) if needed.
-    newPassword = newPassword.trim();
+    newPassword = sanitizeString(newPassword.trim());
 
     const user = await User.findOne({ passwordResetToken: resetToken });
     if (!user) {

--- a/frontend/src/graphql/resolvers/mutations/mealMutations.js
+++ b/frontend/src/graphql/resolvers/mutations/mealMutations.js
@@ -3,6 +3,7 @@ import { MealModel } from '@/models/Meal/index.js';
 import { MealPlanModel } from "@/models/MealPlan/index.js";
 import { RecipeModel } from '@/models/Recipe/index.js';
 import { RestaurantModel } from '@/models/Restaurant/index.js';
+import { sanitizeString } from '@/lib/sanitize.js';
 
 /**
  * Creates a meal within a meal plan.
@@ -56,6 +57,11 @@ export const createMeal = withErrorHandling(async (
 
   const recipe = recipeId ? await RecipeModel.findById(recipeId) : null;
   const restaurant = restaurantId ? await RestaurantModel.findById(restaurantId) : null;
+  if (mealName) mealName = sanitizeString(mealName.trim());
+  if (Array.isArray(ingredients)) {
+    ingredients = ingredients.map(i => sanitizeString(i));
+  }
+  if (notes) notes = sanitizeString(notes.trim());
   const newMeal = await MealModel.create({
     mealPlan: mealPlan._id,
     date,
@@ -131,14 +137,14 @@ export const updateMeal = withErrorHandling(async (
   if (mealType !== undefined) meal.mealType = mealType;
   if (recipeId !== undefined) meal.recipe = recipeId;
   if (restaurantId !== undefined) meal.restaurant = restaurantId;
-  if (mealName !== undefined) meal.mealName = mealName;
+  if (mealName !== undefined) meal.mealName = sanitizeString(mealName.trim());
   if (price !== undefined) meal.price = price;
-  if (ingredients !== undefined) meal.ingredients = ingredients;
+  if (ingredients !== undefined) meal.ingredients = ingredients.map(i => sanitizeString(i));
   if (nutrition !== undefined) meal.nutrition = nutrition;
   if (allergens !== undefined) meal.allergens = allergens;
   if (nutritionFacts !== undefined) meal.nutritionFacts = nutritionFacts;
   if (portionSize !== undefined) meal.portionSize = portionSize;
-  if (notes !== undefined) meal.notes = notes;
+  if (notes !== undefined) meal.notes = sanitizeString(notes.trim());
   return meal.save();
 });
 

--- a/frontend/src/graphql/resolvers/mutations/mealPlanMutations.js
+++ b/frontend/src/graphql/resolvers/mutations/mealPlanMutations.js
@@ -1,6 +1,7 @@
 import { withErrorHandling } from './baseImports.js';
 import User from '@/models/User/index.js';
 import { MealPlanModel } from "@/models/MealPlan/index.js";
+import { sanitizeString } from '@/lib/sanitize.js';
 
 /**
  * Creates a new meal plan.
@@ -24,8 +25,8 @@ export const createMealPlan = withErrorHandling(async (_parent, { userId, startD
     user: user._id,
     startDate,
     endDate,
-    title,
-    status,
+    title: title ? sanitizeString(title.trim()) : title,
+    status: status ? sanitizeString(status.trim()) : status,
     totalCalories,
   });
   return newPlan.populate('user');
@@ -52,8 +53,8 @@ export const updateMealPlan = withErrorHandling(async (_parent, { id, startDate,
   const updateData = {};
   if (startDate !== undefined) updateData.startDate = startDate;
   if (endDate !== undefined) updateData.endDate = endDate;
-  if (title !== undefined) updateData.title = title;
-  if (status !== undefined) updateData.status = status;
+  if (title !== undefined) updateData.title = sanitizeString(title.trim());
+  if (status !== undefined) updateData.status = sanitizeString(status.trim());
   if (totalCalories !== undefined) updateData.totalCalories = totalCalories;
   return MealPlanModel.findByIdAndUpdate(id, updateData, { new: true }).populate('user');
 });

--- a/frontend/src/graphql/resolvers/mutations/recipeMutations.js
+++ b/frontend/src/graphql/resolvers/mutations/recipeMutations.js
@@ -1,6 +1,7 @@
 import { withErrorHandling } from './baseImports.js';
 import User from '@/models/User/index.js';
 import { RecipeModel } from '@/models/Recipe/index.js';
+import { sanitizeString } from '@/lib/sanitize.js';
 import mongoose from 'mongoose';
 
 /**
@@ -45,16 +46,17 @@ export const createRecipe = withErrorHandling(async (_parent, { input }, context
   if (!recipeName || typeof recipeName !== 'string' || !recipeName.trim()) {
     throw new Error('A valid recipe name is required.');
   }
-  recipeName = recipeName.trim();
+  recipeName = sanitizeString(recipeName.trim());
 
   if (!Array.isArray(ingredients) || ingredients.length === 0) {
     throw new Error('At least one ingredient is required.');
   }
+  ingredients = ingredients.map(i => sanitizeString(i));
 
   if (!instructions || typeof instructions !== 'string' || !instructions.trim()) {
     throw new Error('Instructions are required.');
   }
-  instructions = instructions.trim();
+  instructions = sanitizeString(instructions.trim());
 
   if (typeof prepTime !== 'number' || prepTime <= 0) {
     throw new Error('Preparation time must be a positive number.');
@@ -63,7 +65,7 @@ export const createRecipe = withErrorHandling(async (_parent, { input }, context
   if (!difficulty || typeof difficulty !== 'string' || !difficulty.trim()) {
     throw new Error('Difficulty is required.');
   }
-  difficulty = difficulty.trim();
+  difficulty = sanitizeString(difficulty.trim());
 
   // Optional: Validate nutritionFacts, tags, images, estimatedCost if needed
   // For example, ensure estimatedCost is a non-negative number:
@@ -83,6 +85,13 @@ export const createRecipe = withErrorHandling(async (_parent, { input }, context
 
   if (!author) {
     throw new Error('Author not found');
+  }
+
+  if (Array.isArray(tags)) {
+    tags = tags.map(t => sanitizeString(t));
+  }
+  if (Array.isArray(images)) {
+    images = images.map(i => sanitizeString(i));
   }
 
   return RecipeModel.create({
@@ -148,19 +157,19 @@ export const updateRecipe = withErrorHandling(async (
     if (typeof recipeName !== 'string' || !recipeName.trim()) {
       throw new Error('Invalid recipe name');
     }
-    updateData.recipeName = recipeName.trim();
+    updateData.recipeName = sanitizeString(recipeName.trim());
   }
   if (ingredients !== undefined) {
     if (!Array.isArray(ingredients) || ingredients.length === 0) {
       throw new Error('Ingredients must be a non-empty array');
     }
-    updateData.ingredients = ingredients;
+    updateData.ingredients = ingredients.map(i => sanitizeString(i));
   }
   if (instructions !== undefined) {
     if (typeof instructions !== 'string' || !instructions.trim()) {
       throw new Error('Invalid instructions');
     }
-    updateData.instructions = instructions.trim();
+    updateData.instructions = sanitizeString(instructions.trim());
   }
   if (prepTime !== undefined) {
     if (typeof prepTime !== 'number' || prepTime <= 0) {
@@ -172,7 +181,7 @@ export const updateRecipe = withErrorHandling(async (
     if (typeof difficulty !== 'string' || !difficulty.trim()) {
       throw new Error('Invalid difficulty');
     }
-    updateData.difficulty = difficulty.trim();
+    updateData.difficulty = sanitizeString(difficulty.trim());
   }
   if (nutritionFacts !== undefined) {
     updateData.nutritionFacts = nutritionFacts;
@@ -181,13 +190,13 @@ export const updateRecipe = withErrorHandling(async (
     if (!Array.isArray(tags)) {
       throw new Error('Tags must be an array');
     }
-    updateData.tags = tags;
+    updateData.tags = tags.map(t => sanitizeString(t));
   }
   if (images !== undefined) {
     if (!Array.isArray(images)) {
       throw new Error('Images must be an array');
     }
-    updateData.images = images;
+    updateData.images = images.map(i => sanitizeString(i));
   }
   if (estimatedCost !== undefined) {
     if (typeof estimatedCost !== 'number' || estimatedCost < 0) {

--- a/frontend/src/graphql/resolvers/mutations/restaurantMutations.js
+++ b/frontend/src/graphql/resolvers/mutations/restaurantMutations.js
@@ -1,6 +1,7 @@
 import { withErrorHandling } from './baseImports.js';
 import { RestaurantModel } from '@/models/Restaurant/index.js';
 import mongoose from 'mongoose';
+import { sanitizeString } from '@/lib/sanitize.js';
 
 /**
  * Creates a new restaurant.
@@ -45,11 +46,11 @@ export const createRestaurant = withErrorHandling(async (_parent, args, context)
 
   // Sanitize inputs
   const sanitizedData = {
-    restaurantName: restaurantName.trim(),
-    address: address.trim(),
-    phone: phone.trim(),
-    website: website.trim(),
-    cuisineType: cuisineType.trim(),
+    restaurantName: sanitizeString(restaurantName.trim()),
+    address: sanitizeString(address.trim()),
+    phone: sanitizeString(phone.trim()),
+    website: sanitizeString(website.trim()),
+    cuisineType: sanitizeString(cuisineType.trim()),
     priceRange,
   };
 
@@ -89,31 +90,31 @@ export const updateRestaurant = withErrorHandling(async (_parent, { id, restaura
     if (typeof restaurantName !== 'string' || !restaurantName.trim()) {
       throw new Error('Invalid restaurant name');
     }
-    updateData.restaurantName = restaurantName.trim();
+    updateData.restaurantName = sanitizeString(restaurantName.trim());
   }
   if (address !== undefined) {
     if (typeof address !== 'string' || !address.trim()) {
       throw new Error('Invalid address');
     }
-    updateData.address = address.trim();
+    updateData.address = sanitizeString(address.trim());
   }
   if (phone !== undefined) {
     if (typeof phone !== 'string' || !phone.trim()) {
       throw new Error('Invalid phone number');
     }
-    updateData.phone = phone.trim();
+    updateData.phone = sanitizeString(phone.trim());
   }
   if (website !== undefined) {
     if (typeof website !== 'string' || !website.trim()) {
       throw new Error('Invalid website URL');
     }
-    updateData.website = website.trim();
+    updateData.website = sanitizeString(website.trim());
   }
   if (cuisineType !== undefined) {
     if (typeof cuisineType !== 'string' || !cuisineType.trim()) {
       throw new Error('Invalid cuisine type');
     }
-    updateData.cuisineType = cuisineType.trim();
+    updateData.cuisineType = sanitizeString(cuisineType.trim());
   }
   if (priceRange !== undefined) {
     updateData.priceRange = priceRange;

--- a/frontend/src/graphql/resolvers/mutations/reviewMutations.js
+++ b/frontend/src/graphql/resolvers/mutations/reviewMutations.js
@@ -3,6 +3,7 @@ import { Review as ReviewModel } from '@/models/Review/index.js';
 import { RecipeModel } from '@/models/Recipe/index.js';
 import { RestaurantModel } from '@/models/Restaurant/index.js';
 import mongoose from 'mongoose';
+import { sanitizeString } from '@/lib/sanitize.js';
 
 /**
  * Creates a new review.
@@ -43,7 +44,7 @@ export const createReview = withErrorHandling(async (_parent, { targetType, targ
   if (typeof comment !== 'string') {
     throw new Error('Comment must be a string');
   }
-  comment = comment.trim();
+  comment = sanitizeString(comment.trim());
 
   const userId = context.user.userId;
   const newReview = await ReviewModel.create({

--- a/frontend/src/lib/sanitize.js
+++ b/frontend/src/lib/sanitize.js
@@ -1,0 +1,21 @@
+export function sanitizeString(str) {
+  if (typeof str !== 'string') {
+    return str;
+  }
+  return str.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case '&':
+        return '&amp;';
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '"':
+        return '&quot;';
+      case "'":
+        return '&#39;';
+      default:
+        return ch;
+    }
+  });
+}

--- a/frontend/src/tests/unit/sanitize.test.js
+++ b/frontend/src/tests/unit/sanitize.test.js
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitizeString } from '../../lib/sanitize.js';
+
+test('sanitizeString escapes HTML tags', () => {
+  const input = "<script>alert('xss')</script>";
+  const expected = "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;";
+  assert.equal(sanitizeString(input), expected);
+});
+
+test('sanitizeString leaves plain text intact', () => {
+  const input = "Hello World";
+  assert.equal(sanitizeString(input), 'Hello World');
+});


### PR DESCRIPTION
## Summary
- add `sanitizeString` helper to escape HTML
- sanitize user-provided strings across GraphQL mutations
- test sanitization helper with XSS examples

## Testing
- `node --test frontend/src/tests/unit/sanitize.test.js`