### PR TITLE
Fix avatarUrl profile error

### DIFF
--- a/frontend/src/graphql/operations.graphql
+++ b/frontend/src/graphql/operations.graphql
@@ -386,6 +386,7 @@ query GetUser($id: ID!) {
         gender
         measurementSystem
         dailyCalories
+        avatarUrl
         createdAt
     }
 }

--- a/frontend/src/graphql/typeDefs.js
+++ b/frontend/src/graphql/typeDefs.js
@@ -126,6 +126,7 @@ export const typeDefs = gql`
         questionnaire: Questionnaire
         dailyCalories: Int
         nutritionTargets: NutritionTargets
+        avatarUrl: String
         lastLogin: Date
         createdAt: Date!
         updatedAt: Date!


### PR DESCRIPTION
## Summary
- expose `avatarUrl` field on `User` in GraphQL schema
- include `avatarUrl` in the `GetUser` query

## Testing
- `npm run lint` *(fails: `next: not found`)*