### PR TITLE
Add CloudWatch logging and Prometheus metrics

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,11 @@
+# Monitoring and Alerts
+
+This project uses the `winston` logging library to capture application logs.
+Logs can optionally be forwarded to AWS CloudWatch by setting the environment
+variables `AWS_REGION`, `CLOUDWATCH_LOG_GROUP`, and `CLOUDWATCH_LOG_STREAM`.
+
+Basic Prometheus metrics are exposed via the `/api/metrics` endpoint. These
+include request counts and error counts for the GraphQL API.
+
+To set up alerts, configure CloudWatch or Prometheus alert rules for high error
+rates or slow responses based on the collected metrics.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,10 @@
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "zustand": "^5.0.3"
+    "zustand": "^5.0.3",
+    "winston": "^3.10.0",
+    "winston-cloudwatch": "^2.5.0",
+    "prom-client": "^14.1.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.25.9",

--- a/frontend/src/lib/logger.js
+++ b/frontend/src/lib/logger.js
@@ -1,0 +1,32 @@
+import winston from 'winston';
+import WinstonCloudWatch from 'winston-cloudwatch';
+
+const {
+  LOG_LEVEL = 'info',
+  AWS_REGION,
+  CLOUDWATCH_LOG_GROUP,
+  CLOUDWATCH_LOG_STREAM,
+} = process.env;
+
+const transports = [
+  new winston.transports.Console({ level: LOG_LEVEL })
+];
+
+if (AWS_REGION && CLOUDWATCH_LOG_GROUP && CLOUDWATCH_LOG_STREAM) {
+  transports.push(
+    new WinstonCloudWatch({
+      level: LOG_LEVEL,
+      awsRegion: AWS_REGION,
+      logGroupName: CLOUDWATCH_LOG_GROUP,
+      logStreamName: CLOUDWATCH_LOG_STREAM,
+    })
+  );
+}
+
+const logger = winston.createLogger({
+  level: LOG_LEVEL,
+  format: winston.format.json(),
+  transports,
+});
+
+export default logger;

--- a/frontend/src/lib/metrics.js
+++ b/frontend/src/lib/metrics.js
@@ -1,0 +1,15 @@
+import { Counter, register } from 'prom-client';
+
+export const requestCounter = new Counter({
+  name: 'app_requests_total',
+  help: 'Total HTTP requests',
+  labelNames: ['route', 'method', 'status'],
+});
+
+export const errorCounter = new Counter({
+  name: 'app_errors_total',
+  help: 'Total application errors',
+  labelNames: ['route'],
+});
+
+export { register };

--- a/frontend/src/pages/api/metrics.js
+++ b/frontend/src/pages/api/metrics.js
@@ -1,0 +1,10 @@
+import { register } from '@/lib/metrics.js';
+
+export const config = {
+  api: { bodyParser: false },
+};
+
+export default async function handler(req, res) {
+  res.setHeader('Content-Type', register.contentType);
+  res.end(await register.metrics());
+}


### PR DESCRIPTION
## Summary
- add winston logger with optional CloudWatch transport
- instrument GraphQL API with logger and Prometheus counters
- expose `/api/metrics` endpoint
- document monitoring setup

## Testing
- `npm test --silent`