### PR TITLE
Add MongoDB encryption guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The application includes various code implementations, such as:
 **Prerequisites:**
 * Node.js (>=18.18.0 based on `frontend/package.json`) and npm (or Yarn/pnpm/bun).
 * MongoDB instance (local or cloud, e.g., MongoDB Atlas) with a valid connection URI.
+* Encryption at rest is required. Atlas clusters encrypt storage and backups automatically. For local MongoDB, start `mongod` with `--enableEncryption` or use an encrypted volume. See [docs/encryption.md](docs/encryption.md).
 * Environment variables in a `.env.local` file in the `frontend` directory (e.g., `MONGODB_URI`, `JWT_SECRET`, `GOOGLE_PLACES_API_KEY`, `OVERPASS_URL`). The app uses Google Places when a valid key is supplied and falls back to Overpass otherwise.
 
 **Setup & Installation (Frontend):**
@@ -130,6 +131,7 @@ file is present, printing the resulting restaurant list as JSON.
 * [Getting Started](docs/getting_started.md)
 * [User Guide](docs/user_guide.md)
 * [Troubleshooting](docs/troubleshooting.md)
+* [Encryption Guide](docs/encryption.md)
 
 ## Available Scripts (Frontend - from `package.json`)
 * `npm run dev`: Starts the Next.js development server.

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,16 @@
+# Encryption Requirements
+
+Fine Dining requires that all stored data is encrypted at rest. MongoDB Atlas provides encryption at rest by default, including for automated backups. If you deploy your own MongoDB server, enable encryption for the WiredTiger storage engine or use an encrypted filesystem.
+
+## Verifying Encryption in MongoDB Atlas
+1. Navigate to **Security > Advanced** in your Atlas project.
+2. Confirm that **Encryption at Rest** is enabled for your cluster. Atlas-managed backups inherit this setting and are encrypted automatically.
+
+## Local MongoDB with Encrypted Storage
+1. Ensure your MongoDB edition supports the `--enableEncryption` option.
+2. Start `mongod` with `--enableEncryption` and specify `--encryptionKeyFile` or use disk-level encryption such as LUKS or BitLocker.
+3. Store your encryption keys securely and restrict access to them.
+
+## Encrypted Backups
+- Use `mongodump` with the `--ssl` flag and save backup archives to an encrypted volume.
+- For filesystem snapshots, ensure the underlying storage or snapshot service uses encryption.


### PR DESCRIPTION
## Summary
- document requirement for encrypted MongoDB storage and backups
- add new Encryption Guide in docs

## Testing
- `npm test`