### PR TITLE
Add global middleware

### DIFF
--- a/frontend/src/pages/_middleware.js
+++ b/frontend/src/pages/_middleware.js
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { setSecurityHeaders, setCORSHeaders, assignRequestId } from '../utils/headers.js';
+
+export function middleware(req) {
+    const res = NextResponse.next();
+    assignRequestId(res);
+    setSecurityHeaders(res);
+    setCORSHeaders(res, req.headers.get('origin') || '');
+    return res;
+}

--- a/frontend/src/utils/headers.js
+++ b/frontend/src/utils/headers.js
@@ -1,0 +1,52 @@
+// src/utils/headers.js
+
+import { randomUUID } from 'crypto';
+
+const isProduction = process.env.NODE_ENV === 'production';
+const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(',')
+    : ['https://yourdomain.com'];
+
+/**
+ * Sets security headers on the response.
+ * In production, a strict CSP is applied. In development, the CSP is relaxed
+ * to allow inline scripts/eval for tools like Apollo Sandbox.
+ * @param {import('http').ServerResponse | import('next/server').NextResponse} res
+ */
+export function setSecurityHeaders(res) {
+    const csp = isProduction
+        ? "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; object-src 'none'; frame-ancestors 'none';"
+        : "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:;";
+    res.headers.set ? res.headers.set('Content-Security-Policy', csp) : res.setHeader('Content-Security-Policy', csp);
+    res.headers.set ? res.headers.set('X-Frame-Options', 'DENY') : res.setHeader('X-Frame-Options', 'DENY');
+    res.headers.set ? res.headers.set('X-Content-Type-Options', 'nosniff') : res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.headers.set ? res.headers.set('X-XSS-Protection', '1; mode=block') : res.setHeader('X-XSS-Protection', '1; mode=block');
+    res.headers.set ? res.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin') : res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    if (isProduction) {
+        res.headers.set ? res.headers.set('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload') : res.setHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+    }
+}
+
+/**
+ * Sets CORS headers on the response.
+ * @param {import('http').ServerResponse | import('next/server').NextResponse} res
+ * @param {string} origin
+ */
+export function setCORSHeaders(res, origin) {
+    const allowed = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
+    res.headers.set ? res.headers.set('Access-Control-Allow-Origin', allowed) : res.setHeader('Access-Control-Allow-Origin', allowed);
+    res.headers.set ? res.headers.set('Access-Control-Allow-Methods', 'POST, OPTIONS') : res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    res.headers.set ? res.headers.set('Access-Control-Allow-Headers', 'Content-Type, Authorization') : res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+    res.headers.set ? res.headers.set('Access-Control-Allow-Credentials', 'true') : res.setHeader('Access-Control-Allow-Credentials', 'true');
+}
+
+/**
+ * Attaches a unique Request ID to the response.
+ * @param {import('http').ServerResponse | import('next/server').NextResponse} res
+ * @returns {string}
+ */
+export function assignRequestId(res) {
+    const requestId = randomUUID();
+    res.headers.set ? res.headers.set('X-Request-ID', requestId) : res.setHeader('X-Request-ID', requestId);
+    return requestId;
+}


### PR DESCRIPTION
## Summary
- add header helpers to utils
- use helpers in GraphQL API
- add `_middleware.js` to apply headers globally

## Testing
- `npm run test`
- `npm run build` *(fails: `next` not found)*