### PR TITLE
Fix dashboard greeting to use logged in user

### DIFF
--- a/frontend/builder.cjs
+++ b/frontend/builder.cjs
@@ -114,9 +114,16 @@ import React from 'react';
 import { AppBar, Toolbar, IconButton, Avatar, Typography } from '@mui/material';
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 import { useDashStore } from './store';
+import { useAuth } from '../../context/AuthContext';
 
 export default function NewHeader({ user }) {
   const toggleDrawer = useDashStore(s => s.toggleDrawer);
+  let authUser = null;
+  try {
+    authUser = useAuth().user;
+  } catch (e) {
+  }
+  const currentUser = user || authUser;
   return (
     <AppBar elevation={0} sx={{ bgcolor:'primary.main', px:2 }}>
       <Toolbar disableGutters sx={{ justifyContent:'space-between' }}>
@@ -124,7 +131,7 @@ export default function NewHeader({ user }) {
           <MenuRoundedIcon />
         </IconButton>
         <Typography variant="h6" fontWeight={600}>Fine Dining</Typography>
-        <Avatar alt={user?.name} src={user?.avatarUrl} sx={{ width:36, height:36 }} />
+        <Avatar alt={currentUser?.name} src={currentUser?.avatarUrl} sx={{ width:36, height:36 }} />
       </Toolbar>
     </AppBar>
   );
@@ -307,6 +314,7 @@ import RestaurantCard from '../components/dashboard/RestaurantCard';
 import BottomSearchRail from '../components/dashboard/BottomSearchRail';
 import NewNavigationDrawer from '../components/dashboard/NewNavigationDrawer';
 import { useDashStore } from '../components/dashboard/store';
+import { useAuth } from '../context/AuthContext';
 
 /* ------------------------------------------------------------------------ */
 /* Mock fetchers – replace with real data hooks or GraphQL queries.         */
@@ -327,6 +335,7 @@ export default function Dashboard() {
   // auth redirect stub
   /* const { isAuthenticated, loading } = useAuth();
   useEffect(()=>{ if (!loading && !isAuthenticated) router.push('/login'); },[loading]); */
+  const { user: currentUser } = useAuth();
 
   const meal        = useMeal();
   const restaurants = useRestaurants();
@@ -342,7 +351,7 @@ export default function Dashboard() {
     <>
       <Head><title>Fine Dining Dashboard</title></Head>
       <CssBaseline />
-      <NewHeader user={{ name:'Anthony Fine'}} />
+      <NewHeader user={currentUser} />
       <Box
         component="main"
         sx={{
@@ -353,7 +362,7 @@ export default function Dashboard() {
           flexDirection:'column',
         }}
       >
-        <GreetingSegment userName="Anthony" />
+        <GreetingSegment userName={currentUser?.name || 'Guest'} />
         <DailySummary meal={meal} />
         <MealCard meal={meal} />
         <DiscoveryHeader />

--- a/frontend/src/components/Dashboard/NewHeader.js
+++ b/frontend/src/components/Dashboard/NewHeader.js
@@ -6,10 +6,18 @@ import { AppBar, Toolbar, IconButton, Avatar, Typography } from '@mui/material';
 import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 import { useDashStore } from './store';
 import { useRouter } from 'next/router';
+import { useAuth } from '../../context/AuthContext';
 
 export default function NewHeader({ user }) {
   const toggleDrawer = useDashStore(s => s.toggleDrawer);
   const router = useRouter();
+  let authUser = null;
+  try {
+    authUser = useAuth().user;
+  } catch (e) {
+    // Ignore if AuthProvider is not present
+  }
+  const currentUser = user || authUser;
   return (
     <AppBar elevation={0} sx={{ bgcolor:'primary.main', px:2 }}>
       <Toolbar disableGutters sx={{ justifyContent:'space-between' }}>
@@ -23,8 +31,8 @@ export default function NewHeader({ user }) {
           title="Profile"
         >
           <Avatar
-            alt={user?.name}
-            src={user?.avatarUrl}
+            alt={currentUser?.name}
+            src={currentUser?.avatarUrl}
             sx={{ width:36, height:36 }}
           />
         </IconButton>

--- a/frontend/src/pages/dashboard.js
+++ b/frontend/src/pages/dashboard.js
@@ -17,6 +17,7 @@ import OptimizedMealPlanDisplay from '@/components/Dashboard/OptimizedMealPlanDi
 import MealCatalog from '@/components/Dashboard/MealCatalog';
 import NutritionRequirementsForm from '@/components/Dashboard/NutritionRequirementsForm';
 import { useDashStore } from '@/components/Dashboard/store';
+import { useAuth } from '@/context/AuthContext';
 
 const GENERATE_OPTIMIZED_MEAL_PLAN = gql`
   mutation GenerateOptimizedMealPlan($selectedMealIds: [ID], $customNutritionTargets: CustomNutritionTargetsInput) {
@@ -127,6 +128,8 @@ export default function Dashboard() {
   /* const { isAuthenticated, loading } = useAuth();
   useEffect(()=>{ if (!loading && !isAuthenticated) router.push('/login'); },[loading]); */
 
+  const { user } = useAuth();
+
   const meal        = useMeal();
   const [fetchRestaurants, {
     loading: restaurantsLoading,
@@ -235,7 +238,7 @@ export default function Dashboard() {
     <>
       <Head><title>Fine Dining Dashboard</title></Head>
       <CssBaseline />
-      <NewHeader user={{ name:'Anthony Fine'}} />
+      <NewHeader user={user} />
       <Box
         component="main"
         sx={{
@@ -246,7 +249,7 @@ export default function Dashboard() {
           flexDirection:'column',
         }}
       >
-        <GreetingSegment userName="Anthony" />
+        <GreetingSegment userName={user?.name || 'Guest'} />
         <DailySummary meal={meal} />
 
         {/* Tabs for Meal Plan Optimization */}


### PR DESCRIPTION
## Summary
- use AuthContext in Dashboard page
- fetch user information in NewHeader if not provided
- update builder.cjs snippet

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*