### PR TITLE
Add editable profile fields

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,6 +45,7 @@
     "mongoose-encryption": "^2.1.2",
     "next": "^15.3.2",
     "node-fetch": "^3.3.2",
+    "@tanstack/react-query": "^5.38.0",
     "prop-types": "^15.8.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/frontend/src/components/Profile/EditableField.js
+++ b/frontend/src/components/Profile/EditableField.js
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Typography, TextField, IconButton } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import { useMutation } from '@tanstack/react-query';
+import { useToast } from '../../context/ToastContext';
+
+const mutation = `
+mutation UpdateUser($id: ID!, $input: UpdateUserInput!) {
+  updateUser(id: $id, input: $input) {
+    id
+    weight
+    height
+  }
+}`;
+
+async function updateField({ userId, field, value }) {
+  const res = await fetch('/api/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: mutation, variables: { id: userId, input: { [field]: value } } })
+  });
+  const json = await res.json();
+  if (json.errors) {
+    throw new Error(json.errors[0].message);
+  }
+  return json.data.updateUser;
+}
+
+export default function EditableField({ label, field, value: initialValue, unit, userId, measurementSystem }) {
+  const [editing, setEditing] = useState(false);
+  const [value, setValue] = useState(initialValue ?? '');
+  const { showToast } = useToast();
+
+  const isImperial = measurementSystem === 'IMPERIAL';
+  const ranges = {
+    height: isImperial ? [50, 96] : [127, 244],
+    weight: isImperial ? [70, 600] : [32, 272]
+  };
+  const [min, max] = ranges[field] || [undefined, undefined];
+
+  const mutationFn = useMutation({
+    mutationFn: (newValue) => updateField({ userId, field, value: newValue }),
+    onMutate: async (newValue) => {
+      const previous = value;
+      setValue(newValue);
+      return { previous };
+    },
+    onError: (err, newValue, context) => {
+      setValue(context.previous);
+      showToast(`Failed to update ${label.toLowerCase()}`, 'error');
+    }
+  });
+
+  const handleSave = () => {
+    const num = Number(value);
+    if (min !== undefined && (num < min || num > max)) {
+      showToast(`${label} must be between ${min}-${max}${unit}`, 'error');
+      return;
+    }
+    mutationFn.mutate(num);
+    setEditing(false);
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      handleSave();
+    } else if (e.key === 'Escape') {
+      setValue(initialValue ?? '');
+      setEditing(false);
+    }
+  };
+
+  return (
+    <div>
+      <Typography variant="subtitle2">{label}</Typography>
+      {editing ? (
+        <TextField
+          type="number"
+          size="small"
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          onBlur={handleSave}
+          onKeyDown={handleKeyDown}
+          inputProps={{ min, max }}
+        />
+      ) : (
+        <Typography variant="body2" onClick={() => setEditing(true)} sx={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}>
+          {value ?? 'N/A'} {unit}
+          <IconButton size="small" sx={{ ml: 0.5 }}>
+            <EditIcon fontSize="inherit" />
+          </IconButton>
+        </Typography>
+      )}
+    </div>
+  );
+}
+
+EditableField.propTypes = {
+  label: PropTypes.string.isRequired,
+  field: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  unit: PropTypes.string,
+  userId: PropTypes.string.isRequired,
+  measurementSystem: PropTypes.string.isRequired
+};

--- a/frontend/src/components/Profile/ProfileDetails.js
+++ b/frontend/src/components/Profile/ProfileDetails.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card, CardContent, Avatar, Typography, Grid } from '@mui/material';
+import EditableField from './EditableField';
 
 export default function ProfileDetails({ user }) {
   if (!user) return null;
@@ -28,12 +29,24 @@ export default function ProfileDetails({ user }) {
             <Typography variant="body2">{user.accountStatus}</Typography>
           </Grid>
           <Grid item xs={6}>
-            <Typography variant="subtitle2">Weight</Typography>
-            <Typography variant="body2">{user.weight ?? 'N/A'} {weightUnit}</Typography>
+            <EditableField
+              label="Weight"
+              field="weight"
+              value={user.weight}
+              unit={weightUnit}
+              userId={user.id}
+              measurementSystem={user.measurementSystem}
+            />
           </Grid>
           <Grid item xs={6}>
-            <Typography variant="subtitle2">Height</Typography>
-            <Typography variant="body2">{user.height ?? 'N/A'} {heightUnit}</Typography>
+            <EditableField
+              label="Height"
+              field="height"
+              value={user.height}
+              unit={heightUnit}
+              userId={user.id}
+              measurementSystem={user.measurementSystem}
+            />
           </Grid>
           <Grid item xs={6}>
             <Typography variant="subtitle2">Gender</Typography>

--- a/frontend/src/context/ToastContext.js
+++ b/frontend/src/context/ToastContext.js
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+import { Snackbar, Alert } from '@mui/material';
+
+const ToastContext = createContext({ showToast: () => {} });
+
+export const ToastProvider = ({ children }) => {
+  const [toast, setToast] = useState({ open: false, message: '', severity: 'info' });
+
+  const showToast = useCallback((message, severity = 'info') => {
+    setToast({ open: true, message, severity });
+  }, []);
+
+  const handleClose = () => {
+    setToast(t => ({ ...t, open: false }));
+  };
+
+  return (
+    <ToastContext.Provider value={{ showToast }}>
+      {children}
+      <Snackbar open={toast.open} autoHideDuration={4000} onClose={handleClose}>
+        <Alert onClose={handleClose} severity={toast.severity} sx={{ width: '100%' }}>
+          {toast.message}
+        </Alert>
+      </Snackbar>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -18,6 +18,8 @@ import Head from 'next/head';
 import { ThemeProvider, CssBaseline } from '@mui/material';
 import { ApolloProvider, ApolloClient, InMemoryCache, HttpLink } from '@apollo/client';
 import { setContext } from '@apollo/client/link/context';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '../context/ToastContext';
 
 import createEmotionCache from '../utils/createEmotionCache'; // [cite: frontend/src/utils/createEmotionCache.js]
 import { CacheProvider } from '@emotion/react';
@@ -65,6 +67,7 @@ const client = new ApolloClient({
 
 // Create an Emotion cache instance for client-side rendering.
 const clientSideEmotionCache = createEmotionCache(); // [cite: frontend/src/utils/createEmotionCache.js]
+const queryClient = new QueryClient();
 
 /**
  * MyApp - The root component of the Next.js application.
@@ -100,11 +103,15 @@ export default function MyApp(props) {
                 <CssBaseline />
                 {/* Provide the configured Apollo Client to the entire application */}
                 <ApolloProvider client={client}>
-                    {/* Provide the Authentication Context to manage user auth state */}
-                    <AuthProvider>
-                        {/* Render the active page component with its specific props */}
-                        <Component {...pageProps} />
-                    </AuthProvider>
+                    <QueryClientProvider client={queryClient}>
+                        <ToastProvider>
+                            {/* Provide the Authentication Context to manage user auth state */}
+                            <AuthProvider>
+                                {/* Render the active page component with its specific props */}
+                                <Component {...pageProps} />
+                            </AuthProvider>
+                        </ToastProvider>
+                    </QueryClientProvider>
                 </ApolloProvider>
             </ThemeProvider>
         </CacheProvider>


### PR DESCRIPTION
## Summary
- add ToastContext with MUI Snackbar
- wrap app with React Query provider and Toast provider
- create `EditableField` component for inline editing
- use `EditableField` for weight and height in `ProfileDetails`
- add `@tanstack/react-query` dependency

## Testing
- `npm test`