### PR TITLE
Add definition list layout and profile molecule

### DIFF
--- a/frontend/src/components/Profile/ProfileDetailItem.js
+++ b/frontend/src/components/Profile/ProfileDetailItem.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Box, Tooltip, Typography } from '@mui/material';
+
+export default function ProfileDetailItem({ icon, term, definition, tooltip }) {
+  const content = (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+      {icon && <Box component="span">{icon}</Box>}
+      <Box>
+        <Typography component="dt" variant="subtitle2">
+          {term}
+        </Typography>
+        <Typography component="dd" variant="body2" sx={{ m: 0 }}>
+          {definition}
+        </Typography>
+      </Box>
+    </Box>
+  );
+
+  return tooltip ? <Tooltip title={tooltip}>{content}</Tooltip> : content;
+}
+
+ProfileDetailItem.propTypes = {
+  icon: PropTypes.node,
+  term: PropTypes.node.isRequired,
+  definition: PropTypes.node.isRequired,
+  tooltip: PropTypes.string,
+};
+
+ProfileDetailItem.defaultProps = {
+  icon: null,
+  tooltip: '',
+};
+

--- a/frontend/src/components/Profile/ProfileDetails.js
+++ b/frontend/src/components/Profile/ProfileDetails.js
@@ -1,5 +1,20 @@
 import React from 'react';
-import { Card, CardContent, Avatar, Typography, Grid } from '@mui/material';
+import {
+  Card,
+  CardContent,
+  Avatar,
+  Typography,
+  Grid,
+  Box,
+} from '@mui/material';
+import WorkIcon from '@mui/icons-material/Work';
+import VerifiedUserIcon from '@mui/icons-material/VerifiedUser';
+import MonitorWeightIcon from '@mui/icons-material/MonitorWeight';
+import HeightIcon from '@mui/icons-material/Height';
+import WcIcon from '@mui/icons-material/Wc';
+import LocalFireDepartmentIcon from '@mui/icons-material/LocalFireDepartment';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import ProfileDetailItem from './ProfileDetailItem';
 
 export default function ProfileDetails({ user }) {
   if (!user) return null;
@@ -18,36 +33,54 @@ export default function ProfileDetails({ user }) {
             <Typography variant="body2" color="text.secondary">{user.email}</Typography>
           </Grid>
         </Grid>
-        <Grid container spacing={1} sx={{ mt: 2 }}>
-          <Grid item xs={6}>
-            <Typography variant="subtitle2">Role</Typography>
-            <Typography variant="body2">{user.role}</Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="subtitle2">Status</Typography>
-            <Typography variant="body2">{user.accountStatus}</Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="subtitle2">Weight</Typography>
-            <Typography variant="body2">{user.weight ?? 'N/A'} {weightUnit}</Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="subtitle2">Height</Typography>
-            <Typography variant="body2">{user.height ?? 'N/A'} {heightUnit}</Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="subtitle2">Gender</Typography>
-            <Typography variant="body2">{user.gender}</Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="subtitle2">Daily Calories</Typography>
-            <Typography variant="body2">{user.dailyCalories ?? 'N/A'}</Typography>
-          </Grid>
-          <Grid item xs={6}>
-            <Typography variant="subtitle2">Joined</Typography>
-            <Typography variant="body2">{joinDate}</Typography>
-          </Grid>
-        </Grid>
+
+        <Box component="dl" sx={{ mt: 2, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 2 }}>
+          <ProfileDetailItem
+            icon={<WorkIcon fontSize="small" />}
+            term="Role"
+            definition={user.role}
+            tooltip="User role"
+          />
+          <ProfileDetailItem
+            icon={<VerifiedUserIcon fontSize="small" />}
+            term="Status"
+            definition={user.accountStatus}
+            tooltip="Account status"
+          />
+        </Box>
+
+        <Box component="dl" sx={{ mt: 2, display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))', gap: 2 }}>
+          <ProfileDetailItem
+            icon={<MonitorWeightIcon fontSize="small" />}
+            term="Weight"
+            definition={`${user.weight ?? 'N/A'} ${weightUnit}`}
+            tooltip="Current weight"
+          />
+          <ProfileDetailItem
+            icon={<HeightIcon fontSize="small" />}
+            term="Height"
+            definition={`${user.height ?? 'N/A'} ${heightUnit}`}
+            tooltip="Current height"
+          />
+          <ProfileDetailItem
+            icon={<WcIcon fontSize="small" />}
+            term="Gender"
+            definition={user.gender}
+            tooltip="Gender identity"
+          />
+          <ProfileDetailItem
+            icon={<LocalFireDepartmentIcon fontSize="small" />}
+            term="Daily Calories"
+            definition={user.dailyCalories ?? 'N/A'}
+            tooltip="Daily calorie allowance"
+          />
+          <ProfileDetailItem
+            icon={<CalendarTodayIcon fontSize="small" />}
+            term="Joined"
+            definition={joinDate}
+            tooltip="Date joined"
+          />
+        </Box>
       </CardContent>
     </Card>
   );

--- a/frontend/src/components/Questionnaire/QuestionnaireWizard.js
+++ b/frontend/src/components/Questionnaire/QuestionnaireWizard.js
@@ -191,16 +191,52 @@ const WeightGoalStep = ({ data, onChange, onBack }) => {
 };
 WeightGoalStep.propTypes = { data: PropTypes.object.isRequired, onChange: PropTypes.func.isRequired, onBack: PropTypes.func.isRequired };
 
-const SummaryStep = ({ data, onBack }) => (
-  <Box>
-    <Typography variant="h6" gutterBottom>Summary</Typography>
-    <pre>{JSON.stringify(data, null, 2)}</pre>
-    <Box sx={{ mt: 2 }}>
-      <Button variant="outlined" onClick={onBack} sx={{ mr: 1 }}>Back</Button>
-      <Button variant="contained" onClick={() => console.log('submit', data)}>Submit</Button>
+const SummaryStep = ({ data, onBack }) => {
+  const items = [
+    { term: 'Measurement System', value: data.system },
+    {
+      term: 'Gender',
+      value: data.gender === 'other' ? data.otherGender : data.gender,
+    },
+    {
+      term: 'Height',
+      value: `${data.height} ${data.system === 'imperial' ? 'in' : 'cm'}`,
+    },
+    {
+      term: 'Weight',
+      value: `${data.weight} ${data.system === 'imperial' ? 'lbs' : 'kg'}`,
+    },
+    { term: 'Goal', value: data.goal },
+  ];
+  if (data.desired) {
+    items.push({
+      term: 'Desired Weight',
+      value: `${data.desired} ${data.system === 'imperial' ? 'lbs' : 'kg'}`,
+    });
+  }
+
+  return (
+    <Box>
+      <Typography variant="h6" gutterBottom>Summary</Typography>
+      <Box component="dl" sx={{ mt: 1 }}>
+        {items.map((item) => (
+          <Box key={item.term} sx={{ display: 'flex', gap: 1 }}>
+            <Typography component="dt" variant="subtitle2" sx={{ minWidth: 160 }}>
+              {item.term}
+            </Typography>
+            <Typography component="dd" variant="body2" sx={{ m: 0 }}>
+              {item.value}
+            </Typography>
+          </Box>
+        ))}
+      </Box>
+      <Box sx={{ mt: 2 }}>
+        <Button variant="outlined" onClick={onBack} sx={{ mr: 1 }}>Back</Button>
+        <Button variant="contained" onClick={() => console.log('submit', data)}>Submit</Button>
+      </Box>
     </Box>
-  </Box>
-);
+  );
+};
 SummaryStep.propTypes = { data: PropTypes.object.isRequired, onBack: PropTypes.func.isRequired };
 
 // Wizard container ----------------------------------------------------------
@@ -247,3 +283,5 @@ export default function QuestionnaireWizard() {
     </MeasurementProvider>
   );
 }
+
+export { SummaryStep };

--- a/frontend/src/tests/components/ProfileDetails.spec.js
+++ b/frontend/src/tests/components/ProfileDetails.spec.js
@@ -18,4 +18,10 @@ test('renders basic user info', async ({ mount }) => {
   const component = await mount(<ProfileDetails user={user} />);
   await expect(component.getByText('Jane Doe')).toBeVisible();
   await expect(component.getByText('jane@example.com')).toBeVisible();
+
+  const dts = component.locator('dl dt');
+  const dds = component.locator('dl dd');
+  await expect(dts).toHaveCount(7);
+  await expect(dds).toHaveCount(7);
+  await expect(component.locator('dl dt + dd')).toHaveCount(7);
 });

--- a/frontend/src/tests/components/SummaryStep.spec.js
+++ b/frontend/src/tests/components/SummaryStep.spec.js
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import { SummaryStep } from '../../components/Questionnaire/QuestionnaireWizard';
+
+const sample = {
+  gender: 'male',
+  otherGender: '',
+  height: 180,
+  weight: 75,
+  system: 'metric',
+  goal: 'maintain',
+  desired: 0,
+};
+
+test('renders summary definition list in order', async ({ mount }) => {
+  const component = await mount(<SummaryStep data={sample} onBack={() => {}} />);
+  const dts = component.locator('dl dt');
+  const dds = component.locator('dl dd');
+  await expect(dts).toHaveCount(5);
+  await expect(dds).toHaveCount(5);
+  await expect(component.locator('dl dt + dd')).toHaveCount(5);
+});
+


### PR DESCRIPTION
## Summary
- add ProfileDetailItem molecule
- display profile fields using definition lists
- reformat Questionnaire summary step to use `<dl>` elements
- add new SummaryStep component test and update ProfileDetails test

## Testing
- `npm test`
- `NODE_ENV=test-ct npx playwright test --config=playwright-ct.config.js` *(fails: connect EHOSTUNREACH)*