### PR TITLE
Add CalorieProgressRing component

### DIFF
--- a/frontend/src/components/Profile/CalorieProgressRing.js
+++ b/frontend/src/components/Profile/CalorieProgressRing.js
@@ -1,0 +1,70 @@
+import React, { useMemo } from 'react';
+import { gql, useQuery } from '@apollo/client';
+import { Box } from '@mui/material';
+
+const GET_STATS_BY_USER = gql`
+  query GetStatsByUser($userId: ID!) {
+    getStatsByUser(userId: $userId) {
+      id
+      dateLogged
+      caloriesConsumed
+    }
+  }
+`;
+
+export default function CalorieProgressRing({ userId, dailyCalories = 0, consumed }) {
+  const { data } = useQuery(GET_STATS_BY_USER, {
+    variables: { userId },
+    fetchPolicy: 'network-only',
+    skip: consumed !== undefined || !userId,
+  });
+
+  const todayCalories = useMemo(() => {
+    if (consumed !== undefined) return consumed;
+    if (!data?.getStatsByUser) return 0;
+    const today = new Date().toDateString();
+    return data.getStatsByUser
+      .filter(s => new Date(s.dateLogged).toDateString() === today)
+      .reduce((sum, s) => sum + (s.caloriesConsumed || 0), 0);
+  }, [consumed, data]);
+
+  const pct = dailyCalories ? (todayCalories / dailyCalories) * 100 : 0;
+  const displayPct = Math.min(Math.max(pct, 0), 100);
+
+  let color = '#10B981'; // emerald
+  if (pct >= 70 && pct <= 100) color = '#F59E0B'; // amber
+  if (pct > 100) color = '#F43F5E'; // rose
+
+  const size = 80;
+  const strokeWidth = 8;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const offset = circumference - (displayPct / 100) * circumference;
+
+  return (
+    <Box title={`${todayCalories} kcal of ${dailyCalories} kcal`} sx={{ width: size, height: size }}>
+      <svg width={size} height={size}>
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke="#e5e7eb"
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+        <circle
+          cx={size / 2}
+          cy={size / 2}
+          r={radius}
+          stroke={color}
+          strokeWidth={strokeWidth}
+          fill="none"
+          strokeDasharray={circumference}
+          strokeDashoffset={offset}
+          strokeLinecap="round"
+          style={{ transition: 'stroke-dashoffset 0.5s ease' }}
+        />
+      </svg>
+    </Box>
+  );
+}

--- a/frontend/src/components/Profile/ProfileDetails.js
+++ b/frontend/src/components/Profile/ProfileDetails.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Card, CardContent, Avatar, Typography, Grid } from '@mui/material';
+import CalorieProgressRing from './CalorieProgressRing';
 
 export default function ProfileDetails({ user }) {
   if (!user) return null;
@@ -12,6 +13,9 @@ export default function ProfileDetails({ user }) {
         <Grid container spacing={2} alignItems="center">
           <Grid item>
             <Avatar src={user.avatarUrl} alt={user.name} sx={{ width: 64, height: 64 }} />
+          </Grid>
+          <Grid item>
+            <CalorieProgressRing userId={user.id} dailyCalories={user.dailyCalories} />
           </Grid>
           <Grid item xs>
             <Typography variant="h6" fontWeight={600}>{user.name}</Typography>

--- a/frontend/src/tests/components/CalorieProgressRing.spec.js
+++ b/frontend/src/tests/components/CalorieProgressRing.spec.js
@@ -1,0 +1,28 @@
+import React from 'react';
+import { test, expect } from '@playwright/experimental-ct-react';
+import CalorieProgressRing from '../../components/Profile/CalorieProgressRing';
+
+const DAILY = 2000;
+
+test.describe('CalorieProgressRing', () => {
+  test('0% progress', async ({ mount }) => {
+    const component = await mount(<CalorieProgressRing dailyCalories={DAILY} consumed={0} />);
+    const circle = component.locator('circle').nth(1);
+    await expect(circle).toHaveAttribute('stroke', '#10B981');
+    await expect(component).toHaveAttribute('title', `0 kcal of ${DAILY} kcal`);
+  });
+
+  test('50% progress', async ({ mount }) => {
+    const component = await mount(<CalorieProgressRing dailyCalories={DAILY} consumed={1000} />);
+    const circle = component.locator('circle').nth(1);
+    await expect(circle).toHaveAttribute('stroke', '#10B981');
+    await expect(component).toHaveAttribute('title', `1000 kcal of ${DAILY} kcal`);
+  });
+
+  test('over 100% progress', async ({ mount }) => {
+    const component = await mount(<CalorieProgressRing dailyCalories={DAILY} consumed={2500} />);
+    const circle = component.locator('circle').nth(1);
+    await expect(circle).toHaveAttribute('stroke', '#F43F5E');
+    await expect(component).toHaveAttribute('title', `2500 kcal of ${DAILY} kcal`);
+  });
+});


### PR DESCRIPTION
## Summary
- add `CalorieProgressRing` component to display calorie intake progress
- integrate progress ring in profile details
- test progress ring for 0%, 50% and >100% progress states

## Testing
- `npm test`
- `npm run test:components` *(fails: cross-env not found)*