### PR TITLE
Improve stepper accessibility

### DIFF
--- a/frontend/src/components/Questionnaire/QuestionnaireWizard.js
+++ b/frontend/src/components/Questionnaire/QuestionnaireWizard.js
@@ -1,4 +1,10 @@
-import React, { useState, useEffect, createContext, useContext } from 'react';
+import React, {
+  useState,
+  useEffect,
+  createContext,
+  useContext,
+  useRef
+} from 'react';
 import PropTypes from 'prop-types';
 import {
   Box,
@@ -6,6 +12,7 @@ import {
   Stepper,
   Step,
   StepLabel,
+  StepButton,
   RadioGroup,
   FormControlLabel,
   Radio,
@@ -208,6 +215,10 @@ export default function QuestionnaireWizard() {
   const [activeStep, setActiveStep] = useSessionState('wizardStep', 0);
   const [formData, setFormData] = useSessionState('wizardData', {});
 
+  const [focusIdx, setFocusIdx] = useState(activeStep);
+  const stepRefs = useRef([]);
+  const [liveMsg, setLiveMsg] = useState('');
+
   const steps = ['Basic Info', 'Weight Goal', 'Summary'];
 
   const handleBasicNext = (data) => {
@@ -232,16 +243,72 @@ export default function QuestionnaireWizard() {
     }
   };
 
+  useEffect(() => {
+    setFocusIdx(activeStep);
+  }, [activeStep]);
+
+  useEffect(() => {
+    const label = steps[focusIdx];
+    const completed = focusIdx < activeStep ? ' — completed' : '';
+    setLiveMsg(`Step ${focusIdx + 1} of ${steps.length}: ${label}${completed}`);
+  }, [focusIdx, activeStep, steps]);
+
+  const handleKeyDown = (e) => {
+    const max = steps.length - 1;
+    if (['ArrowRight', 'ArrowDown'].includes(e.key)) {
+      e.preventDefault();
+      const next = focusIdx === max ? 0 : focusIdx + 1;
+      setFocusIdx(next);
+      stepRefs.current[next]?.focus();
+    } else if (['ArrowLeft', 'ArrowUp'].includes(e.key)) {
+      e.preventDefault();
+      const prev = focusIdx === 0 ? max : focusIdx - 1;
+      setFocusIdx(prev);
+      stepRefs.current[prev]?.focus();
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setFocusIdx(0);
+      stepRefs.current[0]?.focus();
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setFocusIdx(max);
+      stepRefs.current[max]?.focus();
+    } else if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      setActiveStep(focusIdx);
+    }
+  };
+
   return (
     <MeasurementProvider>
       <Box>
-        <Stepper activeStep={activeStep} sx={{ mb: 3 }}>
+        <Stepper role="list" nonLinear activeStep={activeStep} sx={{ mb: 3 }}>
           {steps.map((label, i) => (
-            <Step key={label} aria-current={activeStep === i ? 'step' : undefined}>
-              <StepLabel>{label}</StepLabel>
+            <Step
+              key={label}
+              completed={i < activeStep}
+              role="listitem"
+              aria-current={activeStep === i ? 'step' : undefined}
+            >
+              <StepButton
+                onClick={() => setActiveStep(i)}
+                ref={(el) => (stepRefs.current[i] = el)}
+                tabIndex={focusIdx === i ? 0 : -1}
+                onFocus={() => setFocusIdx(i)}
+                onKeyDown={handleKeyDown}
+              >
+                <StepLabel>{label}</StepLabel>
+              </StepButton>
             </Step>
           ))}
         </Stepper>
+        <Box
+          role="status"
+          aria-live="polite"
+          sx={{ position: 'absolute', width: 1, height: 1, overflow: 'hidden', clip: 'rect(0 0 0 0)' }}
+        >
+          {liveMsg}
+        </Box>
         {renderStep()}
       </Box>
     </MeasurementProvider>

--- a/frontend/src/tests/components/questionnaireWizard.spec.js
+++ b/frontend/src/tests/components/questionnaireWizard.spec.js
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import QuestionnaireWizard from '../../components/Questionnaire/QuestionnaireWizard';
+import { mountWithGuard } from '../utils/mountWithGuard';
+
+// Helper to focus first step button for keyboard navigation
+async function focusStep(page, stepLocator) {
+  await stepLocator.focus();
+  await expect(stepLocator).toBeFocused();
+}
+
+test.describe('QuestionnaireWizard Stepper accessibility', () => {
+  test('roving tabindex and arrow key navigation', async ({ mount, page }) => {
+    const component = await mountWithGuard(page, mount, <QuestionnaireWizard />);
+    const steps = component.locator('button');
+    await expect(steps).toHaveCount(3);
+
+    // Initial tabindex state
+    await expect(steps.nth(0)).toHaveAttribute('tabindex', '0');
+    await expect(steps.nth(1)).toHaveAttribute('tabindex', '-1');
+
+    await focusStep(page, steps.nth(0));
+    await page.keyboard.press('ArrowRight');
+    await expect(steps.nth(1)).toBeFocused();
+    await expect(steps.nth(1)).toHaveAttribute('tabindex', '0');
+    await expect(steps.nth(0)).toHaveAttribute('tabindex', '-1');
+  });
+
+  test('enter key activates focused step and live region announces state', async ({ mount, page }) => {
+    const component = await mountWithGuard(page, mount, <QuestionnaireWizard />);
+    const steps = component.locator('button');
+    const live = component.locator('[role="status"]');
+
+    await focusStep(page, steps.nth(1));
+    await page.keyboard.press('Enter');
+    await expect(component.locator('li[aria-current="step"]')).toContainText('Weight Goal');
+    await expect(live).toHaveText(/Step 2 of 3: Weight Goal/);
+
+    await focusStep(page, steps.nth(0));
+    await page.keyboard.press('ArrowLeft');
+    // wrap-around should focus last step
+    await expect(steps.nth(2)).toBeFocused();
+    await page.keyboard.press('Space');
+    await expect(component.locator('li[aria-current="step"]')).toContainText('Summary');
+    await expect(live).toHaveText(/Step 3 of 3: Summary/);
+  });
+});


### PR DESCRIPTION
## Summary
- add keyboard roving-tabindex to questionnaire wizard stepper
- mark stepper items with list semantics and live region
- enable keyboard activation for each step
- add regression tests for stepper keyboard use

## Testing
- `NODE_ENV=test-ct npx playwright test src/tests/components/questionnaireWizard.spec.js --config=playwright-ct.config.js` *(fails: connect EHOSTUNREACH)*