### PR TITLE
Add toast notifications with Zustand

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "graphql": "^16.11.0",
     "graphql-tag": "^2.12.6",
     "highs-addon": "^0.9.4",
+    "@headlessui/react": "^1.7.18",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.14.2",
     "mongoose-encryption": "^2.1.2",

--- a/frontend/src/components/Profile/ProfileEditor.js
+++ b/frontend/src/components/Profile/ProfileEditor.js
@@ -1,0 +1,60 @@
+import React, { useState } from 'react';
+import { gql, useMutation } from '@apollo/client';
+import { Box, TextField, Button } from '@mui/material';
+import { useToastStore } from '../../store/toastStore';
+
+const UPDATE_USER = gql`
+  mutation UpdateUser($id: ID!, $input: UpdateUserInput!) {
+    updateUser(id: $id, input: $input) {
+      id
+      name
+      avatarUrl
+    }
+  }
+`;
+
+export default function ProfileEditor({ user }) {
+  const [name, setName] = useState(user.name);
+  const [updateUser] = useMutation(UPDATE_USER);
+  const addToast = useToastStore((s) => s.addToast);
+  const removeToast = useToastStore((s) => s.removeToast);
+
+  const handleSaveName = async () => {
+    const tid = addToast({ message: 'Saving profile…', type: 'info' });
+    try {
+      await updateUser({ variables: { id: user.id, input: { name } } });
+      removeToast(tid);
+      addToast({ message: 'Profile updated', type: 'success' });
+    } catch (err) {
+      removeToast(tid);
+      addToast({ message: 'Update failed', type: 'error' });
+    }
+  };
+
+  const handleAvatar = async (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    const tid = addToast({ message: 'Uploading avatar…', type: 'info' });
+    try {
+      await updateUser({ variables: { id: user.id, input: { avatarUrl: url } } });
+      removeToast(tid);
+      addToast({ message: 'Avatar updated', type: 'success' });
+    } catch (err) {
+      removeToast(tid);
+      addToast({ message: 'Avatar upload failed', type: 'error' });
+    }
+  };
+
+  return (
+    <Box sx={{ mt: 2 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <TextField size="small" value={name} onChange={(e) => setName(e.target.value)} />
+        <Button variant="contained" onClick={handleSaveName}>Save</Button>
+      </Box>
+      <Box sx={{ mt: 2 }}>
+        <input type="file" accept="image/*" onChange={handleAvatar} />
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/ToastStack.js
+++ b/frontend/src/components/ToastStack.js
@@ -1,0 +1,37 @@
+import React, { useEffect } from 'react';
+import { Transition } from '@headlessui/react';
+import { useToastStore } from '../store/toastStore';
+
+export default function ToastStack() {
+  const toasts = useToastStore(s => s.toasts);
+  const removeToast = useToastStore(s => s.removeToast);
+
+  useEffect(() => {
+    const timers = toasts.map(t => setTimeout(() => removeToast(t.id), t.duration || 4000));
+    return () => timers.forEach(clearTimeout);
+  }, [toasts, removeToast]);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 space-y-2">
+      {toasts.map(toast => (
+        <Transition
+          key={toast.id}
+          appear
+          show={true}
+          enter="transform transition duration-300"
+          enterFrom="translate-y-2 opacity-0"
+          enterTo="translate-y-0 opacity-100"
+          leave="transition duration-300"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div
+            className={`p-3 rounded shadow text-sm border ${toast.type === 'error' ? 'border-red-500 text-red-700 bg-red-50' : 'border-green-500 text-green-700 bg-green-50'}`}
+          >
+            {toast.message}
+          </div>
+        </Transition>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -23,6 +23,7 @@ import createEmotionCache from '../utils/createEmotionCache'; // [cite: frontend
 import { CacheProvider } from '@emotion/react';
 import useCustomTheme from '../theme/useCustomTheme'; // [cite: frontend/src/theme/useCustomTheme.js]
 import { AuthProvider } from '../context/AuthContext';
+import ToastStack from '../components/ToastStack';
 
 /**
  * Creates an authenticated Apollo Link that attaches the authorization token to every request.
@@ -104,6 +105,7 @@ export default function MyApp(props) {
                     <AuthProvider>
                         {/* Render the active page component with its specific props */}
                         <Component {...pageProps} />
+                        <ToastStack />
                     </AuthProvider>
                 </ApolloProvider>
             </ThemeProvider>

--- a/frontend/src/pages/profile.js
+++ b/frontend/src/pages/profile.js
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import { gql, useQuery } from '@apollo/client';
 import QuestionnaireWizard from '../components/Questionnaire/QuestionnaireWizard';
 import ProfileDetails from '../components/Profile/ProfileDetails';
+import ProfileEditor from '../components/Profile/ProfileEditor';
 import { useAuth } from '../context/AuthContext';
 import styles from '@/styles/ProfilePage.module.css';
 
@@ -51,7 +52,12 @@ export default function ProfilePage() {
       </Typography>
       {loading && <CircularProgress />}
       {error && <Alert severity="error">Failed to load profile.</Alert>}
-      {data?.getUser && <ProfileDetails user={data.getUser} />}
+      {data?.getUser && (
+        <>
+          <ProfileDetails user={data.getUser} />
+          <ProfileEditor user={data.getUser} />
+        </>
+      )}
       <Typography variant="body1" className={styles.description} sx={{ mt: 3 }}>
         Update your preferences below.
       </Typography>

--- a/frontend/src/store/toastStore.js
+++ b/frontend/src/store/toastStore.js
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+
+export const useToastStore = create((set) => ({
+  toasts: [],
+  queue: [],
+  /**
+   * Add a toast to the stack. If the stack already contains 3 toasts,
+   * the toast is queued until space is available.
+   * @param {{message:string,type:'success'|'error'|'info',duration?:number,id?:string}} toast
+   * @returns {string} The toast id.
+   */
+  addToast(toast) {
+    const id = toast.id || String(Date.now() + Math.random());
+    const newToast = { ...toast, id };
+    set((state) => {
+      if (state.toasts.length >= 3) {
+        return { queue: [...state.queue, newToast] };
+      }
+      return { toasts: [...state.toasts, newToast] };
+    });
+    return id;
+  },
+  /** Remove a toast by id and pull next toast from the queue if available. */
+  removeToast(id) {
+    set((state) => {
+      const remaining = state.toasts.filter((t) => t.id !== id);
+      const next = state.queue[0];
+      const rest = state.queue.slice(1);
+      if (next && remaining.length < 3) {
+        return { toasts: [...remaining, next], queue: rest };
+      }
+      return { toasts: remaining, queue: rest.length ? rest : state.queue };
+    });
+  },
+  /** Clear all toasts and queue (used for tests). */
+  reset() {
+    set({ toasts: [], queue: [] });
+  },
+}));

--- a/frontend/src/tests/unit/toastStore.test.js
+++ b/frontend/src/tests/unit/toastStore.test.js
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { useToastStore } from '../../store/toastStore.js';
+
+function reset() {
+  useToastStore.getState().reset();
+}
+
+test('queues toasts beyond limit', () => {
+  reset();
+  useToastStore.getState().addToast({ message: 't1', type: 'success' });
+  useToastStore.getState().addToast({ message: 't2', type: 'success' });
+  useToastStore.getState().addToast({ message: 't3', type: 'success' });
+  useToastStore.getState().addToast({ message: 't4', type: 'success' });
+  const { toasts, queue } = useToastStore.getState();
+  assert.equal(toasts.length, 3);
+  assert.equal(queue.length, 1);
+});
+
+test('removing toast pulls from queue', () => {
+  reset();
+  const id1 = useToastStore.getState().addToast({ message: 'a', type: 'success' });
+  useToastStore.getState().addToast({ message: 'b', type: 'success' });
+  useToastStore.getState().addToast({ message: 'c', type: 'success' });
+  useToastStore.getState().addToast({ message: 'd', type: 'success' });
+  useToastStore.getState().removeToast(id1);
+  const { toasts, queue } = useToastStore.getState();
+  assert.equal(toasts.length, 3);
+  assert.equal(queue.length, 0);
+  assert.ok(toasts.some(t => t.message === 'd'));
+});
+
+test('optimistic and final toasts sync with latency', async () => {
+  reset();
+  const simulate = () => new Promise(res => setTimeout(res, 50));
+  const optimisticId = useToastStore.getState().addToast({ message: 'Saving…', type: 'info' });
+  const p = simulate().then(() => {
+    useToastStore.getState().removeToast(optimisticId);
+    useToastStore.getState().addToast({ message: 'Saved', type: 'success' });
+  });
+  assert.equal(useToastStore.getState().toasts.length, 1);
+  await p;
+  const { toasts } = useToastStore.getState();
+  assert.equal(toasts.length, 1);
+  assert.equal(toasts[0].message, 'Saved');
+});


### PR DESCRIPTION
## Summary
- implement a Zustand toast store with queuing
- create `ToastStack` animated with Headless UI
- show editor for user name and avatar updates
- wire ToastStack into `_app`
- expose profile editor on the profile page
- test toast queueing and latency behaviour

## Testing
- `npm test`