### PR TITLE
Add persistent theme preference

### DIFF
--- a/frontend/src/components/ThemeToggle.js
+++ b/frontend/src/components/ThemeToggle.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { ToggleButtonGroup, ToggleButton } from '@mui/material';
+import LightModeIcon from '@mui/icons-material/LightMode';
+import DarkModeIcon from '@mui/icons-material/DarkMode';
+import { useThemePreference } from '../context/ThemePreferenceContext';
+
+export default function ThemeToggle(props) {
+    const { mode, setMode } = useThemePreference();
+
+    const handleChange = (_, value) => {
+        if (value) setMode(value);
+    };
+
+    return (
+        <ToggleButtonGroup
+            value={mode}
+            exclusive
+            onChange={handleChange}
+            size="small"
+            {...props}
+        >
+            <ToggleButton value="light" aria-label="light mode">
+                <LightModeIcon fontSize="small" />
+            </ToggleButton>
+            <ToggleButton value="dark" aria-label="dark mode">
+                <DarkModeIcon fontSize="small" />
+            </ToggleButton>
+        </ToggleButtonGroup>
+    );
+}

--- a/frontend/src/context/ThemePreferenceContext.js
+++ b/frontend/src/context/ThemePreferenceContext.js
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+const ThemePreferenceContext = createContext({ mode: 'light', setMode: () => {} });
+
+export function ThemePreferenceProvider({ children }) {
+    const [mode, setMode] = useState(() => {
+        if (typeof window !== 'undefined') {
+            const stored = localStorage.getItem('themeMode');
+            if (stored === 'light' || stored === 'dark') return stored;
+            if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
+        }
+        return 'light';
+    });
+
+    useEffect(() => {
+        if (typeof window !== 'undefined') {
+            localStorage.setItem('themeMode', mode);
+        }
+    }, [mode]);
+
+    return (
+        <ThemePreferenceContext.Provider value={{ mode, setMode }}>
+            {children}
+        </ThemePreferenceContext.Provider>
+    );
+}
+
+export const useThemePreference = () => useContext(ThemePreferenceContext);

--- a/frontend/src/pages/_app.js
+++ b/frontend/src/pages/_app.js
@@ -22,6 +22,7 @@ import { setContext } from '@apollo/client/link/context';
 import createEmotionCache from '../utils/createEmotionCache'; // [cite: frontend/src/utils/createEmotionCache.js]
 import { CacheProvider } from '@emotion/react';
 import useCustomTheme from '../theme/useCustomTheme'; // [cite: frontend/src/theme/useCustomTheme.js]
+import { ThemePreferenceProvider } from '../context/ThemePreferenceContext';
 import { AuthProvider } from '../context/AuthContext';
 
 /**
@@ -82,8 +83,6 @@ const clientSideEmotionCache = createEmotionCache(); // [cite: frontend/src/util
 export default function MyApp(props) {
     // Destructure props with a default fallback for emotionCache.
     const { Component, pageProps, emotionCache = clientSideEmotionCache } = props;
-    // Retrieve the custom Material UI theme (e.g., light/dark modes) using the custom hook.
-    const { theme } = useCustomTheme(); // [cite: frontend/src/theme/useCustomTheme.js]
 
     return (
         // The CacheProvider makes the Emotion cache available throughout the component tree.
@@ -94,20 +93,24 @@ export default function MyApp(props) {
                 {/* Set a default page title */}
                 <title>Fine Dining</title> {/* Corrected typo from FineDinning */}
             </Head>
-            {/* Apply the custom Material UI theme */}
-            <ThemeProvider theme={theme}>
-                {/* Apply global CSS reset using MUI's baseline */}
-                <CssBaseline />
-                {/* Provide the configured Apollo Client to the entire application */}
-                <ApolloProvider client={client}>
-                    {/* Provide the Authentication Context to manage user auth state */}
-                    <AuthProvider>
-                        {/* Render the active page component with its specific props */}
-                        <Component {...pageProps} />
-                    </AuthProvider>
-                </ApolloProvider>
-            </ThemeProvider>
+            <ThemePreferenceProvider>
+                <ThemedApp Component={Component} pageProps={pageProps} />
+            </ThemePreferenceProvider>
         </CacheProvider>
+    );
+}
+
+function ThemedApp({ Component, pageProps }) {
+    const { theme } = useCustomTheme();
+    return (
+        <ThemeProvider theme={theme}>
+            <CssBaseline />
+            <ApolloProvider client={client}>
+                <AuthProvider>
+                    <Component {...pageProps} />
+                </AuthProvider>
+            </ApolloProvider>
+        </ThemeProvider>
     );
 }
 

--- a/frontend/src/pages/profile.js
+++ b/frontend/src/pages/profile.js
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import { gql, useQuery } from '@apollo/client';
 import QuestionnaireWizard from '../components/Questionnaire/QuestionnaireWizard';
 import ProfileDetails from '../components/Profile/ProfileDetails';
+import ThemeToggle from '../components/ThemeToggle';
 import { useAuth } from '../context/AuthContext';
 import styles from '@/styles/ProfilePage.module.css';
 
@@ -55,6 +56,9 @@ export default function ProfilePage() {
       <Typography variant="body1" className={styles.description} sx={{ mt: 3 }}>
         Update your preferences below.
       </Typography>
+      <Box sx={{ my: 2 }}>
+        <ThemeToggle />
+      </Box>
       <Box>
         <QuestionnaireWizard />
       </Box>

--- a/frontend/src/theme/useCustomTheme.js
+++ b/frontend/src/theme/useCustomTheme.js
@@ -4,21 +4,21 @@
  */
 
 import { useMemo } from 'react';
-import { createTheme, useMediaQuery } from '@mui/material';
+import { createTheme } from '@mui/material';
 import lightThemeOptions from './lightTheme';
 import darkThemeOptions from './darkTheme';
+import { useThemePreference } from '../context/ThemePreferenceContext';
 
 /**
  * useCustomTheme - Hook to choose between light or dark theme
  * @returns {object} theme - The Material UI theme
  */
 export default function useCustomTheme() {
-    // Check system preference for dark mode
-    const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
+    const { mode } = useThemePreference();
 
     const theme = useMemo(() => {
-        return createTheme(prefersDarkMode ? darkThemeOptions : lightThemeOptions);
-    }, [prefersDarkMode]);
+        return createTheme(mode === 'dark' ? darkThemeOptions : lightThemeOptions);
+    }, [mode]);
 
     return { theme };
 }


### PR DESCRIPTION
## Summary
- store theme mode in localStorage
- provide `ThemePreferenceProvider` context
- allow toggling via new `ThemeToggle` component
- show theme toggle on profile page
- wrap app with preference provider to restore theme

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run test:playwright` *(fails: EHOSTUNREACH)*