### PR TITLE
Add skeleton loading and CLS test

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,7 +51,8 @@
     "zustand": "^5.0.3",
     "winston": "^3.10.0",
     "winston-cloudwatch": "^2.5.0",
-    "prom-client": "^14.1.1"
+    "prom-client": "^14.1.1",
+    "@tanstack/react-query": "^5.36.0"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.25.9",
@@ -65,7 +66,8 @@
     "eslint": "^9.26.0",
     "eslint-config-next": "15.3.2",
     "postcss": "^8.5.3",
-    "tailwindcss": "^4.1.6"
+    "tailwindcss": "^4.1.6",
+    "lighthouse": "^10.4.0"
   },
   "optionalDependencies": {
     "opencl": "^1.0.0"

--- a/frontend/src/pages/profile.js
+++ b/frontend/src/pages/profile.js
@@ -1,8 +1,20 @@
-import React from 'react';
-import { Container, Typography, Box, CircularProgress, Alert, Button } from '@mui/material';
+import React, { useEffect, useState } from 'react';
+import {
+  Container,
+  Typography,
+  Box,
+  Alert,
+  Button,
+  Skeleton,
+  Fade,
+  Card,
+  CardContent,
+  Grid,
+} from '@mui/material';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import { useRouter } from 'next/router';
-import { gql, useQuery } from '@apollo/client';
+import { gql, useApolloClient } from '@apollo/client';
+import { useQuery as useRQ } from '@tanstack/react-query';
 import QuestionnaireWizard from '../components/Questionnaire/QuestionnaireWizard';
 import ProfileDetails from '../components/Profile/ProfileDetails';
 import { useAuth } from '../context/AuthContext';
@@ -27,45 +39,107 @@ const GET_USER = gql`
   }
 `;
 
+const ProfileSkeleton = () => (
+  <Box>
+    <Skeleton variant="rectangular" width={80} height={32} sx={{ mb: 2 }} />
+    <Skeleton variant="text" width="40%" height={32} />
+    <Card elevation={0} sx={{ mt: 2, borderColor: 'surface.light', borderWidth: 1, borderStyle: 'solid', borderRadius: 2 }}>
+      <CardContent>
+        <Grid container spacing={2} alignItems="center">
+          <Grid item>
+            <Skeleton variant="circular" width={64} height={64} />
+          </Grid>
+          <Grid item xs>
+            <Skeleton variant="text" width="80%" />
+            <Skeleton variant="text" width="60%" />
+          </Grid>
+        </Grid>
+        <Grid container spacing={1} sx={{ mt: 2 }}>
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Grid item xs={6} key={i}>
+              <Skeleton variant="text" width="80%" />
+              <Skeleton variant="text" width="60%" />
+            </Grid>
+          ))}
+        </Grid>
+      </CardContent>
+    </Card>
+    <Skeleton variant="text" width="80%" sx={{ mt: 3 }} />
+    <Skeleton variant="rectangular" width={120} height={36} sx={{ mt: 2 }} />
+  </Box>
+);
+
 export default function ProfilePage() {
   const router = useRouter();
   const { user, logout } = useAuth();
-  const { data, loading, error } = useQuery(GET_USER, {
-    skip: !user,
-    variables: { id: user?.id },
-    fetchPolicy: 'network-only'
+  const client = useApolloClient();
+
+  const {
+    data,
+    isLoading,
+    error,
+  } = useRQ({
+    queryKey: ['user', user?.id],
+    queryFn: async () => {
+      const { data } = await client.query({
+        query: GET_USER,
+        variables: { id: user.id },
+        fetchPolicy: 'network-only',
+      });
+      return data.getUser;
+    },
+    enabled: !!user,
   });
+
+  const [showSkeleton, setShowSkeleton] = useState(true);
+  useEffect(() => {
+    let timer;
+    if (!isLoading) {
+      timer = setTimeout(() => setShowSkeleton(false), 400);
+    } else {
+      setShowSkeleton(true);
+    }
+    return () => clearTimeout(timer);
+  }, [isLoading]);
 
   return (
     <Container maxWidth="sm" className={styles.container}>
-      <Button
-        startIcon={<ArrowBackIcon />}
-        onClick={() => router.back()}
-        size="small"
-        sx={{ mb: 2 }}
-      >
-        Back
-      </Button>
-      <Typography variant="h5" gutterBottom className={styles.heading}>
-        Profile
-      </Typography>
-      {loading && <CircularProgress />}
-      {error && <Alert severity="error">Failed to load profile.</Alert>}
-      {data?.getUser && <ProfileDetails user={data.getUser} />}
-      <Typography variant="body1" className={styles.description} sx={{ mt: 3 }}>
-        Update your preferences below.
-      </Typography>
-      <Box>
-        <QuestionnaireWizard />
-      </Box>
-      <Button
-        variant="outlined"
-        color="secondary"
-        onClick={logout}
-        sx={{ mt: 3 }}
-      >
-        Log Out
-      </Button>
+      <Fade in={showSkeleton} timeout={{ enter: 200, exit: 200 }} unmountOnExit>
+        <Box>
+          <ProfileSkeleton />
+        </Box>
+      </Fade>
+      <Fade in={!showSkeleton} timeout={{ enter: 200, exit: 200 }} unmountOnExit>
+        <Box>
+          <Button
+            startIcon={<ArrowBackIcon />}
+            onClick={() => router.back()}
+            size="small"
+            sx={{ mb: 2 }}
+          >
+            Back
+          </Button>
+          <Typography variant="h5" gutterBottom className={styles.heading}>
+            Profile
+          </Typography>
+          {error && <Alert severity="error">Failed to load profile.</Alert>}
+          {data && <ProfileDetails user={data} />}
+          <Typography variant="body1" className={styles.description} sx={{ mt: 3 }}>
+            Update your preferences below.
+          </Typography>
+          <Box>
+            <QuestionnaireWizard />
+          </Box>
+          <Button
+            variant="outlined"
+            color="secondary"
+            onClick={logout}
+            sx={{ mt: 3 }}
+          >
+            Log Out
+          </Button>
+        </Box>
+      </Fade>
     </Container>
   );
 }

--- a/frontend/src/tests/e2e/profile-lighthouse.spec.js
+++ b/frontend/src/tests/e2e/profile-lighthouse.spec.js
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import lighthouse from 'lighthouse';
+import { chromium } from 'playwright';
+
+// Basic Lighthouse check for CLS
+// This test assumes the Next.js dev server is running via Playwright config.
+
+test('profile page CLS below 0.1', async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('http://localhost:3000/profile');
+
+  const port = new URL(browser.wsEndpoint()).port;
+  const { lhr } = await lighthouse('http://localhost:3000/profile', {
+    port,
+    output: 'json',
+    logLevel: 'error',
+    onlyCategories: ['performance'],
+  });
+  const cls = lhr.audits['cumulative-layout-shift'].numericValue;
+  await browser.close();
+  expect(cls).toBeLessThan(0.1);
+});


### PR DESCRIPTION
## Summary
- add React Query and lighthouse to frontend
- gate profile page with React Query and skeletons
- include skeletons for profile layout and actions
- add lighthouse CLS check via Playwright

## Testing
- `npm test`
- `npm run test:playwright` *(fails: connect EHOSTUNREACH)*