### PR TITLE
Add meal plan pages and tests

### DIFF
--- a/frontend/src/pages/meal-plans/[id].js
+++ b/frontend/src/pages/meal-plans/[id].js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { useRouter } from 'next/router';
+import { gql, useQuery } from '@apollo/client';
+import { Container, Typography, CircularProgress, Alert, List, ListItem, ListItemText, Button } from '@mui/material';
+import { useAuth } from '@/context/AuthContext';
+
+const GET_MEAL_PLAN = gql`
+  query GetMealPlan($id: ID!) {
+    getMealPlan(id: $id) {
+      id
+      title
+      startDate
+      endDate
+      meals {
+        id
+        mealName
+      }
+    }
+  }
+`;
+
+export default function MealPlanDetailPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { user } = useAuth();
+
+  const { data, loading, error } = useQuery(GET_MEAL_PLAN, {
+    skip: !id || !user,
+    variables: { id },
+    fetchPolicy: 'network-only',
+  });
+
+  const plan = data?.getMealPlan;
+
+  return (
+    <Container maxWidth="sm">
+      <Button onClick={() => router.back()} sx={{ mb: 2 }}>
+        Back
+      </Button>
+      {loading && <CircularProgress />}
+      {error && <Alert severity="error">Failed to load meal plan.</Alert>}
+      {plan && (
+        <>
+          <Typography variant="h5" gutterBottom>
+            {plan.title || 'Meal Plan'}
+          </Typography>
+          <Typography variant="body1" sx={{ mb: 2 }}>
+            {plan.startDate} - {plan.endDate}
+          </Typography>
+          <List>
+            {plan.meals.map((meal) => (
+              <ListItem key={meal.id}>
+                <ListItemText primary={meal.mealName} />
+              </ListItem>
+            ))}
+          </List>
+        </>
+      )}
+    </Container>
+  );
+}

--- a/frontend/src/pages/meal-plans/index.js
+++ b/frontend/src/pages/meal-plans/index.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import Link from 'next/link';
+import { gql, useQuery, useMutation } from '@apollo/client';
+import { Container, Typography, List, ListItem, ListItemText, Button, CircularProgress, Alert } from '@mui/material';
+import { useAuth } from '@/context/AuthContext';
+
+const GET_MEAL_PLANS = gql`
+  query GetMealPlans($userId: ID) {
+    getMealPlans(userId: $userId) {
+      id
+      title
+      startDate
+      endDate
+    }
+  }
+`;
+
+const CREATE_MEAL_PLAN = gql`
+  mutation CreateMealPlan($userId: ID!, $startDate: Date!, $endDate: Date!) {
+    createMealPlan(userId: $userId, startDate: $startDate, endDate: $endDate) {
+      id
+    }
+  }
+`;
+
+export default function MealPlansPage() {
+  const { user } = useAuth();
+  const { data, loading, error, refetch } = useQuery(GET_MEAL_PLANS, {
+    skip: !user,
+    variables: { userId: user?.id },
+    fetchPolicy: 'network-only',
+  });
+
+  const [createMealPlan, { loading: creating }] = useMutation(CREATE_MEAL_PLAN, {
+    onCompleted: () => refetch(),
+  });
+
+  const handleCreate = () => {
+    if (!user) return;
+    const start = new Date();
+    const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
+    const startDate = start.toISOString().split('T')[0];
+    const endDate = end.toISOString().split('T')[0];
+    createMealPlan({ variables: { userId: user.id, startDate, endDate } });
+  };
+
+  return (
+    <Container maxWidth="sm">
+      <Typography variant="h5" gutterBottom>
+        Meal Plans
+      </Typography>
+      <Button variant="contained" onClick={handleCreate} disabled={creating} sx={{ mb: 2 }}>
+        {creating ? 'Creating...' : 'Create Meal Plan'}
+      </Button>
+      {loading && <CircularProgress />}
+      {error && <Alert severity="error">Failed to load meal plans.</Alert>}
+      <List>
+        {data?.getMealPlans?.map((plan) => (
+          <ListItem button component={Link} href={`/meal-plans/${plan.id}`} key={plan.id}>
+            <ListItemText
+              primary={plan.title || `${plan.startDate} - ${plan.endDate}`}
+            />
+          </ListItem>
+        ))}
+      </List>
+    </Container>
+  );
+}

--- a/frontend/src/tests/e2e/mealplans.spec.js
+++ b/frontend/src/tests/e2e/mealplans.spec.js
@@ -1,0 +1,56 @@
+import { test, expect } from '@playwright/test';
+import { faker } from '@faker-js/faker';
+
+async function gqlPost(request, query, variables = {}) {
+  const response = await request.post('/api/graphql', {
+    headers: { 'Content-Type': 'application/json' },
+    data: { query, variables },
+  });
+  return response.json();
+}
+
+test('create and view meal plans', async ({ request }) => {
+  const email = faker.internet.email();
+  const password = faker.internet.password();
+
+  const createUser = `
+    mutation ($input: CreateUserInput!) {
+      createUser(input: $input) { id }
+    }
+  `;
+  const { data: userData } = await gqlPost(request, createUser, {
+    input: {
+      name: faker.person.fullName(),
+      email,
+      password,
+      gender: 'OTHER',
+      measurementSystem: 'METRIC',
+    },
+  });
+  const userId = userData.createUser.id;
+  expect(userId).toBeTruthy();
+
+  const createPlan = `
+    mutation ($userId: ID!, $startDate: Date!, $endDate: Date!) {
+      createMealPlan(userId: $userId, startDate: $startDate, endDate: $endDate) { id }
+    }
+  `;
+  const { data: planData } = await gqlPost(request, createPlan, {
+    userId,
+    startDate: '2030-01-01',
+    endDate: '2030-01-07',
+  });
+  const planId = planData.createMealPlan.id;
+  expect(planId).toBeTruthy();
+
+  const listQuery = `query ($userId: ID!) { getMealPlans(userId: $userId) { id } }`;
+  const { data: listData } = await gqlPost(request, listQuery, { userId });
+  expect(listData.getMealPlans.some((p) => p.id === planId)).toBe(true);
+
+  const detailQuery = `query ($id: ID!) { getMealPlan(id: $id) { id } }`;
+  const { data: detailData } = await gqlPost(request, detailQuery, { id: planId });
+  expect(detailData.getMealPlan.id).toBe(planId);
+
+  await gqlPost(request, `mutation ($id: ID!) { deleteMealPlan(id: $id) }`, { id: planId });
+  await gqlPost(request, `mutation ($id: ID!) { deleteUser(id: $id) }`, { id: userId });
+});


### PR DESCRIPTION
## Summary
- list meal plans and create new plans
- view details of a meal plan with its meals
- exercise meal plan flow via new e2e test

## Testing
- `npm --prefix frontend run test:playwright` *(fails: Playwright tests failed)*