### PR TITLE
Add restaurant fetch and scraping docs

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -54,3 +54,32 @@ node scripts/test-optimization.mjs
 ```
 
 See the [User Guide](./user_guide.md) for more details on command-line usage and examples.
+
+## Fetch Local Restaurants
+
+You can quickly query nearby restaurants from the command line using
+`fetch-local-restaurants.mjs`:
+
+```bash
+node scripts/fetch-local-restaurants.mjs <lat> <lon> [radius] [keyword]
+```
+
+The script reads `GOOGLE_PLACES_API_KEY` and the optional `OVERPASS_URL`
+from `.env.local`. If the Google key is missing or invalid it falls back to
+the Overpass API. Results are printed as JSON.
+
+## Menu Scraping Pipeline
+
+To collect menu data from major chains and produce a processed CSV, run the
+pipeline located under `frontend/src/lib/HiGHS`:
+
+```bash
+cd frontend/src/lib/HiGHS
+npm install
+node src/main_pipeline.mjs
+```
+
+The pipeline fetches menu items, normalizes them, and writes
+`data/processed/restaurant_meals_processed.csv`. Progress messages are printed
+to the console. No additional environment variables are required beyond those
+defined earlier.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -155,6 +155,31 @@ OVERPASS_URL=https://overpass-api.de/api/interpreter
 
 If `GOOGLE_PLACES_API_KEY` is missing or a request fails, the service falls back to OpenStreetMap Overpass. Results may be less complete and lack ratings. If no `.env.local` file is present, the default Overpass endpoint is used automatically.
 
+### Fetch Local Restaurants
+
+Use the helper script to retrieve nearby restaurants from the command line:
+
+```bash
+node scripts/fetch-local-restaurants.mjs <lat> <lon> [radius] [keyword]
+```
+
+`GOOGLE_PLACES_API_KEY` and the optional `OVERPASS_URL` are read from your
+`.env.local`. Results are printed as JSON.
+
+### Menu Scraping Pipeline
+
+The scraping pipeline under `src/lib/HiGHS` collects menu data and outputs a
+CSV file:
+
+```bash
+cd src/lib/HiGHS
+npm install
+node src/main_pipeline.mjs
+```
+
+On completion you will find `data/processed/restaurant_meals_processed.csv` in
+the same directory.
+
 ## Testing
 
 The project uses Playwright for both end-to-end and component testing.


### PR DESCRIPTION
## Summary
- document `fetch-local-restaurants.mjs` usage
- add instructions on running the menu-scraping pipeline

## Testing
- `npm test`