### PR TITLE
Add menu item GraphQL support

### DIFF
--- a/frontend/src/graphql/resolvers/index.js
+++ b/frontend/src/graphql/resolvers/index.js
@@ -6,7 +6,7 @@
 
 import { Query } from './queries';
 import { Mutation } from './mutations';
-import { MealPlan, Meal, Stats, Review, DateScalar } from './resolversFields';
+import { MealPlan, Meal, Stats, Review, MenuItem, DateScalar } from './resolversFields';
 
 /**
  * @file index.js
@@ -22,5 +22,6 @@ export const resolvers = {
     MealPlan,
     Meal,
     Stats,
-    Review
+    Review,
+    MenuItem
 };

--- a/frontend/src/graphql/resolvers/mutations/index.js
+++ b/frontend/src/graphql/resolvers/mutations/index.js
@@ -7,6 +7,7 @@ import * as mealMutations from './mealMutations.js';
 import * as statsMutations from './statsMutations.js';
 import * as reviewMutations from './reviewMutations.js';
 import * as optimizationMutations from './optimizationMutations.js';
+import * as menuItemMutations from './menuItemMutations.js';
 
 export const Mutation = {
   ...userMutations,
@@ -18,4 +19,5 @@ export const Mutation = {
   ...statsMutations,
   ...reviewMutations,
   ...optimizationMutations,
+  ...menuItemMutations,
 };

--- a/frontend/src/graphql/resolvers/mutations/menuItemMutations.js
+++ b/frontend/src/graphql/resolvers/mutations/menuItemMutations.js
@@ -1,0 +1,62 @@
+import { withErrorHandling } from './baseImports.js';
+import { MenuItemModel } from '@/models/MenuItem/index.js';
+import { RestaurantModel } from '@/models/Restaurant/index.js';
+import mongoose from 'mongoose';
+import { sanitizeString } from '@/lib/sanitize.js';
+
+export const createMenuItem = withErrorHandling(async (
+  _parent,
+  { restaurantId, mealName, price, description, allergens, nutritionFacts },
+  context
+) => {
+  if (!context.user?.userId) {
+    throw new Error('Authentication required');
+  }
+  if (!mongoose.Types.ObjectId.isValid(restaurantId)) {
+    throw new Error('Invalid restaurant ID');
+  }
+  const restaurant = await RestaurantModel.findById(restaurantId);
+  if (!restaurant) {
+    throw new Error('Restaurant not found');
+  }
+  const data = {
+    restaurant: restaurantId,
+    mealName: sanitizeString(mealName),
+    price,
+    description: description ? sanitizeString(description) : '',
+    allergens: allergens || [],
+    nutritionFacts: nutritionFacts || ''
+  };
+  return MenuItemModel.create(data);
+});
+
+export const updateMenuItem = withErrorHandling(async (
+  _parent,
+  { id, mealName, price, description, allergens, nutritionFacts },
+  context
+) => {
+  if (!context.user?.userId) {
+    throw new Error('Authentication required');
+  }
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    throw new Error('Invalid menu item ID');
+  }
+  const updateData = {};
+  if (mealName !== undefined) updateData.mealName = sanitizeString(mealName);
+  if (price !== undefined) updateData.price = price;
+  if (description !== undefined) updateData.description = sanitizeString(description);
+  if (allergens !== undefined) updateData.allergens = allergens;
+  if (nutritionFacts !== undefined) updateData.nutritionFacts = nutritionFacts;
+  return MenuItemModel.findByIdAndUpdate(id, updateData, { new: true });
+});
+
+export const deleteMenuItem = withErrorHandling(async (_parent, { id }, context) => {
+  if (!context.user?.userId) {
+    throw new Error('Authentication required');
+  }
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    throw new Error('Invalid menu item ID');
+  }
+  const result = await MenuItemModel.findByIdAndDelete(id);
+  return Boolean(result);
+});

--- a/frontend/src/graphql/resolvers/queries/index.js
+++ b/frontend/src/graphql/resolvers/queries/index.js
@@ -6,6 +6,7 @@ import * as mealPlanQueries from './mealPlanQueries.js';
 import * as mealQueries from './mealQueries.js';
 import * as statsQueries from './statsQueries.js';
 import * as reviewQueries from './reviewQueries.js';
+import * as menuItemQueries from './menuItemQueries.js';
 
 export const Query = {
   ...generalQueries,
@@ -16,4 +17,5 @@ export const Query = {
   ...mealQueries,
   ...statsQueries,
   ...reviewQueries,
+  ...menuItemQueries,
 };

--- a/frontend/src/graphql/resolvers/queries/menuItemQueries.js
+++ b/frontend/src/graphql/resolvers/queries/menuItemQueries.js
@@ -1,0 +1,25 @@
+import { withErrorHandling } from './baseQueries.js';
+import { MenuItemModel } from '@/models/MenuItem/index.js';
+import mongoose from 'mongoose';
+import { paginateQuery } from '@/utils/pagination.js';
+
+export const getMenuItem = withErrorHandling(async (_parent, { id }) => {
+  if (!mongoose.Types.ObjectId.isValid(id)) {
+    throw new Error('Invalid menu item ID');
+  }
+  return MenuItemModel.findById(id).populate('restaurant');
+});
+
+export const getMenuItemsByRestaurant = withErrorHandling(async (
+  _parent,
+  { restaurantId, page, limit }
+) => {
+  if (!mongoose.Types.ObjectId.isValid(restaurantId)) {
+    throw new Error('Invalid restaurant ID');
+  }
+  return paginateQuery(
+    MenuItemModel.find({ restaurant: restaurantId }).populate('restaurant'),
+    page,
+    limit
+  );
+});

--- a/frontend/src/graphql/resolvers/resolversFields.js
+++ b/frontend/src/graphql/resolvers/resolversFields.js
@@ -73,3 +73,9 @@ export const Review = {
         return User.findById(parent.user);
     },
 };
+
+export const MenuItem = {
+    async restaurant(parent) {
+        return RestaurantModel.findById(parent.restaurant);
+    },
+};

--- a/frontend/src/graphql/typeDefs.js
+++ b/frontend/src/graphql/typeDefs.js
@@ -342,6 +342,21 @@ export const typeDefs = gql`
     }
 
     """
+    Represents a menu item belonging to a restaurant.
+    """
+    type MenuItem {
+        id: ID!
+        restaurant: Restaurant!
+        mealName: String!
+        price: Float
+        description: String
+        allergens: [String]
+        nutritionFacts: String
+        createdAt: Date!
+        updatedAt: Date!
+    }
+
+    """
     Statistics on presolve reduction.
     """
     type PresolveStats {
@@ -441,6 +456,8 @@ export const typeDefs = gql`
         getStatsByUser(userId: ID!): [Stats]
         getReview(id: ID!): Review
         getReviewsForTarget(targetType: String!, targetId: ID!): [Review]
+        getMenuItem(id: ID!): MenuItem
+        getMenuItemsByRestaurant(restaurantId: ID!, page: Int, limit: Int): [MenuItem]
         findNearbyRestaurants(
             latitude: Float!,
             longitude: Float!,
@@ -567,6 +584,23 @@ export const typeDefs = gql`
             priceRange: PriceRange
         ): Restaurant
         deleteRestaurant(id: ID!): Boolean
+        createMenuItem(
+            restaurantId: ID!,
+            mealName: String!,
+            price: Float,
+            description: String,
+            allergens: [String],
+            nutritionFacts: String
+        ): MenuItem!
+        updateMenuItem(
+            id: ID!,
+            mealName: String,
+            price: Float,
+            description: String,
+            allergens: [String],
+            nutritionFacts: String
+        ): MenuItem
+        deleteMenuItem(id: ID!): Boolean
         createMealPlan(
             userId: ID!
             startDate: Date!

--- a/frontend/src/models/MenuItem/index.js
+++ b/frontend/src/models/MenuItem/index.js
@@ -1,0 +1,7 @@
+import MenuItemModel from './menuItem.model.js';
+import menuItemSchema from './menuItem.schema.js';
+
+export {
+  MenuItemModel,
+  menuItemSchema
+};

--- a/frontend/src/models/MenuItem/menuItem.model.js
+++ b/frontend/src/models/MenuItem/menuItem.model.js
@@ -1,0 +1,6 @@
+import mongoose from 'mongoose';
+import menuItemSchema from './menuItem.schema.js';
+
+const MenuItemModel = mongoose.models.MenuItem || mongoose.model('MenuItem', menuItemSchema);
+
+export default MenuItemModel;

--- a/frontend/src/models/MenuItem/menuItem.schema.js
+++ b/frontend/src/models/MenuItem/menuItem.schema.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+
+const menuItemSchema = new Schema(
+  {
+    restaurant: { type: Schema.Types.ObjectId, ref: 'Restaurant', required: true },
+    mealName: { type: String, required: true, trim: true },
+    price: { type: Number, default: 0 },
+    description: { type: String, default: '' },
+    allergens: { type: [String], default: [] },
+    nutritionFacts: { type: String, default: '' }
+  },
+  { timestamps: true }
+);
+
+export default menuItemSchema;


### PR DESCRIPTION
## Summary
- support new `MenuItem` model
- expose menu item CRUD in GraphQL schema
- handle menu item queries/mutations in resolvers
- let `MealCatalog` fetch menu items by restaurant

## Testing
- `npm test`