### PR TITLE
Add menu scraping util and MenuItem model

### DIFF
--- a/frontend/scripts/fetch-menus.mjs
+++ b/frontend/scripts/fetch-menus.mjs
@@ -1,0 +1,73 @@
+/**
+ * @file fetch-menus.mjs
+ * Fetch websites for restaurants using Overpass and scrape menu items.
+ */
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+import fetch from 'node-fetch';
+import { dbConnect } from '../src/lib/dbConnect.js';
+import { RestaurantModel } from '../src/models/Restaurant/index.js';
+import { MenuItemModel } from '../src/models/MenuItem/index.js';
+import { scrapeMenu } from '../src/lib/menuScraper.mjs';
+
+dotenv.config({ path: '.env.local' });
+
+const OVERPASS_URL = process.env.OVERPASS_URL || 'https://overpass-api.de/api/interpreter';
+
+async function fetchWebsite(name) {
+  const query = `[out:json][timeout:25];node["name"~"${name}"]["website"];out 1;`;
+  const body = `data=${encodeURIComponent(query)}`;
+  const res = await fetch(OVERPASS_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body,
+  });
+  if (!res.ok) return null;
+  const data = await res.json();
+  const el = data.elements && data.elements[0];
+  return el?.tags?.website || null;
+}
+
+async function main() {
+  await dbConnect();
+  const restaurants = await RestaurantModel.find();
+
+  for (const rest of restaurants) {
+    if (!rest.website) {
+      const site = await fetchWebsite(rest.restaurantName);
+      if (site) {
+        rest.website = site;
+        await rest.save();
+        console.log(`Updated website for ${rest.restaurantName}`);
+      }
+    }
+
+    if (!rest.website) continue;
+
+    try {
+      const items = await scrapeMenu(rest.website);
+      for (const item of items) {
+        await MenuItemModel.create({
+          restaurant: rest._id,
+          name: item.name,
+          price: item.price ?? 0,
+          calories: item.calories ?? 0,
+          protein: item.protein ?? 0,
+          carbohydrates: item.carbohydrates ?? 0,
+          fat: item.fat ?? 0,
+          sodium: item.sodium ?? 0,
+        });
+      }
+      console.log(`Saved ${items.length} items for ${rest.restaurantName}`);
+    } catch (e) {
+      console.error(`Failed to scrape ${rest.restaurantName}:`, e.message);
+    }
+  }
+
+  await mongoose.disconnect();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/frontend/src/lib/menuScraper.mjs
+++ b/frontend/src/lib/menuScraper.mjs
@@ -1,0 +1,51 @@
+import fetch from 'node-fetch';
+import * as cheerio from 'cheerio';
+
+/**
+ * Scrape menu items and basic nutrition info from a restaurant website.
+ * The scraper looks for elements containing menu item text and attempts
+ * to extract common nutrition values via regular expressions.
+ *
+ * @param {string} url - The website URL to scrape.
+ * @returns {Promise<Array>} Array of menu item objects.
+ */
+export async function scrapeMenu(url) {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.statusText}`);
+  }
+
+  const html = await res.text();
+  const $ = cheerio.load(html);
+  const items = [];
+
+  const candidates = $('.menu-item, .item, li, div');
+  candidates.each((i, el) => {
+    const text = $(el).text().replace(/\s+/g, ' ').trim();
+    if (!text) return;
+
+    const nameMatch = text.match(/^([^\d$]+?)\s*(?:-|\$|\d|cal|g|mg)/i);
+    const priceMatch = text.match(/\$(\d+(?:\.\d+)?)/);
+    const caloriesMatch = text.match(/(\d+)\s*cal/i);
+    const proteinMatch = text.match(/(\d+)\s*g\s*protein/i);
+    const carbsMatch = text.match(/(\d+)\s*g\s*carb/i);
+    const fatMatch = text.match(/(\d+)\s*g\s*fat/i);
+    const sodiumMatch = text.match(/(\d+)\s*mg\s*sodium/i);
+
+    const name = nameMatch ? nameMatch[1].trim() : text.slice(0, 50);
+    const item = {
+      name,
+      price: priceMatch ? parseFloat(priceMatch[1]) : null,
+      calories: caloriesMatch ? parseInt(caloriesMatch[1]) : null,
+      protein: proteinMatch ? parseInt(proteinMatch[1]) : null,
+      carbohydrates: carbsMatch ? parseInt(carbsMatch[1]) : null,
+      fat: fatMatch ? parseInt(fatMatch[1]) : null,
+      sodium: sodiumMatch ? parseInt(sodiumMatch[1]) : null,
+    };
+
+    // Require at least a name
+    if (item.name) items.push(item);
+  });
+
+  return items;
+}

--- a/frontend/src/models/MenuItem/index.js
+++ b/frontend/src/models/MenuItem/index.js
@@ -1,0 +1,4 @@
+import MenuItemModel from './menuItem.model.js';
+import menuItemSchema from './menuItem.schema.js';
+
+export { MenuItemModel, menuItemSchema };

--- a/frontend/src/models/MenuItem/menuItem.model.js
+++ b/frontend/src/models/MenuItem/menuItem.model.js
@@ -1,0 +1,5 @@
+import mongoose from 'mongoose';
+import menuItemSchema from './menuItem.schema.js';
+
+const MenuItemModel = mongoose.models.MenuItem || mongoose.model('MenuItem', menuItemSchema);
+export default MenuItemModel;

--- a/frontend/src/models/MenuItem/menuItem.schema.js
+++ b/frontend/src/models/MenuItem/menuItem.schema.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+
+const menuItemSchema = new mongoose.Schema(
+  {
+    restaurant: { type: mongoose.Schema.Types.ObjectId, ref: 'Restaurant', required: true },
+    name: { type: String, required: true, trim: true },
+    price: { type: Number, default: 0 },
+    calories: { type: Number, default: 0 },
+    protein: { type: Number, default: 0 },
+    carbohydrates: { type: Number, default: 0 },
+    fat: { type: Number, default: 0 },
+    sodium: { type: Number, default: 0 },
+  },
+  { timestamps: true, collection: 'menuItems' }
+);
+
+export default menuItemSchema;

--- a/frontend/src/services/providers/OverpassProvider.js
+++ b/frontend/src/services/providers/OverpassProvider.js
@@ -35,6 +35,7 @@ out center;`;
         placeId: `${el.type}-${el.id}`,
         name: el.tags?.name || 'Unnamed restaurant',
         vicinity: el.tags?.['addr:full'] || el.tags?.['addr:street'] || el.tags?.city || 'Unknown',
+        website: el.tags?.website || null,
         rating: null,
         userRatingsTotal: null,
         location: {


### PR DESCRIPTION
## Summary
- return website field from Overpass provider results
- create a generic menu scraper using node-fetch and cheerio
- add MenuItem mongoose schema/model
- script to fetch restaurant websites from Overpass and scrape menus

## Testing
- `npm test`