### PR TITLE
Add help modal with accessibility

### DIFF
--- a/frontend/src/components/Profile/HelpModal.js
+++ b/frontend/src/components/Profile/HelpModal.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  Button,
+  Box
+} from '@mui/material';
+import Image from 'next/image';
+import copy from '../../i18n/en.json';
+
+export default function HelpModal({ open, onClose }) {
+  const { title, description, image } = copy.help.desiredWeight;
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      aria-labelledby="help-dialog-title"
+    >
+      <DialogTitle id="help-dialog-title">{title}</DialogTitle>
+      <DialogContent>
+        <DialogContentText>{description}</DialogContentText>
+        <Box sx={{ mt: 2, textAlign: 'center' }}>
+          <Image src={image} alt={title} width={120} height={120} />
+        </Box>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} autoFocus>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}
+
+HelpModal.propTypes = {
+  open: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired
+};

--- a/frontend/src/components/Questionnaire/QuestionnaireWizard.js
+++ b/frontend/src/components/Questionnaire/QuestionnaireWizard.js
@@ -10,8 +10,13 @@ import {
   FormControlLabel,
   Radio,
   TextField,
-  Typography
+  Typography,
+  IconButton,
+  InputAdornment,
+  Tooltip
 } from '@mui/material';
+import InfoOutlined from '@mui/icons-material/InfoOutlined';
+import HelpModal from '../Profile/HelpModal';
 
 // Measurement system context -------------------------------------------------
 const MeasurementContext = createContext();
@@ -157,6 +162,7 @@ const WeightGoalStep = ({ data, onChange, onBack }) => {
   const [goal, setGoal] = useState(data.goal || 'maintain');
   const [desired, setDesired] = useState(data.desired || '');
   const { system } = useMeasurement();
+  const [helpOpen, setHelpOpen] = useState(false);
 
   useEffect(() => {
     onChange({ goal, desired });
@@ -181,7 +187,23 @@ const WeightGoalStep = ({ data, onChange, onBack }) => {
         fullWidth
         size="small"
         sx={{ mt: 2 }}
+        InputProps={{
+          endAdornment: (
+            <InputAdornment position="end">
+              <Tooltip title="What is desired weight?">
+                <IconButton
+                  size="small"
+                  onClick={() => setHelpOpen(true)}
+                  aria-label="Desired weight help"
+                >
+                  <InfoOutlined fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            </InputAdornment>
+          )
+        }}
       />
+      <HelpModal open={helpOpen} onClose={() => setHelpOpen(false)} />
       <Box sx={{ mt: 2, display: 'flex', gap: 1 }}>
         <Button variant="outlined" onClick={onBack}>Back</Button>
         <Button variant="contained" onClick={() => onChange({ goal, desired, complete: true })}>Next</Button>
@@ -247,3 +269,4 @@ export default function QuestionnaireWizard() {
     </MeasurementProvider>
   );
 }
+export { WeightGoalStep };

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -1,0 +1,9 @@
+{
+  "help": {
+    "desiredWeight": {
+      "title": "Desired Weight",
+      "description": "This is the target weight you aim to reach.",
+      "image": "/plate-logo.png"
+    }
+  }
+}

--- a/frontend/src/tests/components/WeightGoalStep.accessibility.spec.js
+++ b/frontend/src/tests/components/WeightGoalStep.accessibility.spec.js
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/experimental-ct-react';
+import { WeightGoalStep } from '../../components/Questionnaire/QuestionnaireWizard';
+
+const noop = () => {};
+
+test('info modal accessible with keyboard', async ({ mount, page }) => {
+  const component = await mount(
+    <WeightGoalStep data={{}} onChange={noop} onBack={noop} />
+  );
+  const info = component.getByLabel('Desired weight help');
+  await info.focus();
+  await expect(info).toBeFocused();
+  await page.keyboard.press('Enter');
+  const dialog = component.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+  const closeBtn = dialog.getByRole('button', { name: /close/i });
+  await expect(closeBtn).toBeFocused();
+  await page.keyboard.press('Escape');
+  await expect(dialog).not.toBeVisible();
+});


### PR DESCRIPTION
## Summary
- create `HelpModal` component for profile help
- add info icon to `WeightGoalStep` that opens `HelpModal`
- export `WeightGoalStep` for testing
- add English copy for modal text
- test keyboard accessibility of the help modal

## Testing
- `npm run test:components` *(fails: cross-env not found)*