### PR TITLE
Fix dashboard meal plan id

### DIFF
--- a/frontend/src/pages/dashboard.js
+++ b/frontend/src/pages/dashboard.js
@@ -95,6 +95,15 @@ const GET_MEALS = gql`
   }
 `;
 
+const GET_MEAL_PLANS = gql`
+  query GetMealPlans($userId: ID) {
+    getMealPlans(userId: $userId) {
+      id
+      status
+    }
+  }
+`;
+
 const useDailyMeals = (count = 3) => {
   const { data } = useQuery(GET_MEALS, {
     variables: { page: 1, limit: count },
@@ -130,6 +139,18 @@ export default function Dashboard() {
   useEffect(()=>{ if (!loading && !isAuthenticated) router.push('/login'); },[loading]); */
 
   const { user } = useAuth();
+
+  const { data: mealPlanData } = useQuery(GET_MEAL_PLANS, {
+    variables: { userId: user?.id },
+    skip: !user,
+    fetchPolicy: 'cache-first',
+  });
+
+  const activeMealPlanId = useMemo(() => {
+    const plans = mealPlanData?.getMealPlans || [];
+    const activePlan = plans.find(p => p.status === 'ACTIVE') || plans[0];
+    return activePlan?.id;
+  }, [mealPlanData]);
 
   const meal        = useMeal();
   const [fetchRestaurants, {
@@ -221,8 +242,11 @@ export default function Dashboard() {
   };
 
   // Handle adding selected meals to the active meal plan
-  const activeMealPlanId = 'YOUR_MEAL_PLAN_ID'; // TODO: replace with real ID
   const handleAddMeals = async (meals) => {
+    if (!activeMealPlanId) {
+      console.error('No active meal plan available to add meals.');
+      return;
+    }
     try {
       for (const meal of meals) {
         await createMeal({


### PR DESCRIPTION
## Summary
- look up meal plans via GraphQL in Dashboard
- use the first active meal plan id when adding meals
- log error when there is no plan
- run the frontend build to ensure compilation (fails because `next` is missing)

## Testing
- `npm run build` *(fails: next not found)*