### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm install
+      - name: Lint
+        run: npm run lint
+      - name: Unit tests
+        run: npm test
+      - name: Playwright tests
+        run: npm run test:playwright
+      - name: Build
+        run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextjs-build
+          path: frontend/.next
+

--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ file is present, printing the resulting restaurant list as JSON.
 * `npm run codegen`: Generates GraphQL types from your schema (`codegen.yml`).
 * `npm run benchmark:gpu`: Runs a matrix multiplication benchmark using the GPU module.
 
+## Continuous Integration
+The repository uses a GitHub Actions workflow defined in
+`.github/workflows/ci.yml`. The workflow runs on Node.js 18 and performs the
+following steps:
+
+1. Checks out the code.
+2. Installs dependencies inside the `frontend` directory.
+3. Lints the project with `npm run lint`.
+4. Runs unit tests via `npm test`.
+5. Executes Playwright tests with `npm run test:playwright`.
+6. Builds the Next.js application and uploads the `.next` directory as a build
+   artifact.
+
 ## License
 This project is currently not licensed under an open-source license.
 © 2025 FineWare LLC. All rights reserved.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow using Node 18 for the frontend
- document CI workflow steps in README

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND)*
- `npm run test:playwright` *(no output)*