### PR TITLE
Fix react-query dependency duplication

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -20,7 +20,7 @@
         "@mui/icons-material": "^7.0.1",
         "@mui/material": "^7.0.1",
         "@playwright/experimental-ct-react": "^1.52.0",
-        "@tanstack/react-query": "^5.36.0",
+        "@tanstack/react-query": "^5.38.0",
         "bcrypt": "^6.0.0",
         "bcryptjs": "^3.0.2",
         "browser-image-compression": "^2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -55,8 +55,7 @@
     "zustand": "^5.0.3",
     "winston": "^3.10.0",
     "winston-cloudwatch": "^2.5.0",
-    "prom-client": "^14.1.1",
-    "@tanstack/react-query": "^5.36.0"
+    "prom-client": "^14.1.1"
   },
   "devDependencies": {
     "@babel/plugin-transform-class-properties": "^7.25.9",


### PR DESCRIPTION
## Summary
- remove duplicate `@tanstack/react-query` entry from frontend `package.json`
- update lock file accordingly

## Testing
- `npm test` *(fails: ERR_MODULE_NOT_FOUND for zustand)*