### PR TITLE
Add file descriptions and JSDoc to components

### DIFF
--- a/frontend/src/components/Dashboard/BottomSearchRail.js
+++ b/frontend/src/components/Dashboard/BottomSearchRail.js
@@ -1,4 +1,7 @@
 /**
+ * @fileoverview BottomSearchRail component
+ */
+/**
  * @file BottomSearchRail.js
  * @description Hardened, bottom‑right, expandable search bar that plays well
  *              with both client and server renders.
@@ -43,6 +46,11 @@ const sanitizeInput = (v) =>
     typeof v === 'string' ? v.replace(/[<>&"']/g, '') : '';
 
 /* ----------------------------------------------------------------------- */
+/**
+ * BottomSearchRail component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 const BottomSearchRail = ({ storeHook = defaultDashStore }) => {
   /* ---------- store interaction (fallback‑safe) ------------------------ */
   if (typeof storeHook !== 'function') {

--- a/frontend/src/components/Dashboard/DailySummary.js
+++ b/frontend/src/components/Dashboard/DailySummary.js
@@ -1,4 +1,7 @@
 /**
+ * @fileoverview DailySummary component
+ */
+/**
  * DailySummary — all components now share the dynamic tint colour.
  */
 import React, { useState, useEffect, useMemo } from 'react';
@@ -213,6 +216,11 @@ PlaceholderCard.defaultProps = {
 };
 
 /* ─── DailySummary Organism ───────────────────────────────────────── */
+/**
+ * DailySummary component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function DailySummary({ meals, loading, onAddMeal }) {
     // 1‑second heartbeat loader
     const [pulse, setPulse] = useState(loading);

--- a/frontend/src/components/Dashboard/DayOverview.js
+++ b/frontend/src/components/Dashboard/DayOverview.js
@@ -1,9 +1,17 @@
+/**
+ * @fileoverview DayOverview component
+ */
 // src/components/Dashboard/DayOverview.js
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Card, CardMedia, Typography } from '@mui/material';
 // Removed style constants/functions
 
+/**
+ * DayOverview component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 const DayOverview = React.memo(({ meal }) => {
     if (!meal) return null;
 

--- a/frontend/src/components/Dashboard/DiscoveryHeader.js
+++ b/frontend/src/components/Dashboard/DiscoveryHeader.js
@@ -1,9 +1,17 @@
 /**
+ * @fileoverview DiscoveryHeader component
+ */
+/**
  * Section header for the restaurant discovery list.
  */
 import React from 'react';
 import { Typography } from '@mui/material';
 
+/**
+ * DiscoveryHeader component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function DiscoveryHeader() {
   return (
     <Typography variant="h6" fontWeight={600} sx={{ mt:3 }}>

--- a/frontend/src/components/Dashboard/GreetingSegment.js
+++ b/frontend/src/components/Dashboard/GreetingSegment.js
@@ -1,10 +1,18 @@
 /**
+ * @fileoverview GreetingSegment component
+ */
+/**
  * Greeting banner with teal background and rounded corners.
  */
 import React from 'react';
 import { Box, Typography, Button } from '@mui/material';
 import { useRouter } from 'next/router';
 
+/**
+ * GreetingSegment component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function GreetingSegment({ userName='Guest' }) {
   const router = useRouter();
   return (

--- a/frontend/src/components/Dashboard/Header.js
+++ b/frontend/src/components/Dashboard/Header.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview Header component
+ */
 // src/components/Dashboard/Header.js
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -6,6 +9,11 @@ import MenuRoundedIcon from '@mui/icons-material/MenuRounded';
 import FoodBankIcon from '@mui/icons-material/FoodBank';
 // Removed useTheme and style constants/functions
 
+/**
+ * Header component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 const Header = React.memo(({ user, onMenuClick }) => {
     // Removed theme = useTheme()
 

--- a/frontend/src/components/Dashboard/MealCard.js
+++ b/frontend/src/components/Dashboard/MealCard.js
@@ -1,9 +1,17 @@
 /**
+ * @fileoverview MealCard component
+ */
+/**
  * Full‑bleed hero image card for the day’s meal.
  */
 import React from 'react';
 import { Card, CardMedia, CardContent, Typography, Box } from '@mui/material';
 
+/**
+ * MealCard component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function MealCard({ meal }) {
   if (!meal) return null;
   return (

--- a/frontend/src/components/Dashboard/MealCatalog.js
+++ b/frontend/src/components/Dashboard/MealCatalog.js
@@ -1,4 +1,7 @@
 /**
+ * @fileoverview MealCatalog component
+ */
+/**
  * MealCatalog.js
  * 
  * Component to display the meal catalog and allow users to select meals.

--- a/frontend/src/components/Dashboard/NavigationDrawer.js
+++ b/frontend/src/components/Dashboard/NavigationDrawer.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview NavigationDrawer component
+ */
 // src/components/Dashboard/NavigationDrawer.js
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -18,6 +21,11 @@ import FoodBankIcon from '@mui/icons-material/FoodBank';
 // Drawer width is typically handled via sx or MUI props
 const drawerWidth = 250;
 
+/**
+ * NavigationDrawer component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 const NavigationDrawer = React.memo(({ open, onClose }) => {
 
     const handleNavigate = (page) => {

--- a/frontend/src/components/Dashboard/NewHeader.js
+++ b/frontend/src/components/Dashboard/NewHeader.js
@@ -1,4 +1,7 @@
 /**
+ * @fileoverview NewHeader component
+ */
+/**
  * Brand header — fixed top bar with avatar + burger.
  */
 import React from 'react';
@@ -9,6 +12,11 @@ import { useDashStore } from './store';
 import { useRouter } from 'next/router';
 import { useAuth } from '../../context/AuthContext';
 
+/**
+ * NewHeader component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function NewHeader({ user }) {
   const toggleDrawer = useDashStore(s => s.toggleDrawer);
   const router = useRouter();

--- a/frontend/src/components/Dashboard/NewNavigationDrawer.js
+++ b/frontend/src/components/Dashboard/NewNavigationDrawer.js
@@ -1,4 +1,7 @@
 /**
+ * @fileoverview NewNavigationDrawer component
+ */
+/**
  * Right‑aligned navigation drawer with brand links.
  */
 import React from 'react';
@@ -7,6 +10,11 @@ import { Drawer, List, ListItemButton, ListItemText } from '@mui/material';
 import { useDashStore } from './store';
 import { useAuth } from '../../context/AuthContext';
 
+/**
+ * NewNavigationDrawer component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function NewNavigationDrawer() {
   const { drawerOpen, toggleDrawer } = useDashStore();
   const router = useRouter();

--- a/frontend/src/components/Dashboard/NutritionRequirementsForm.js
+++ b/frontend/src/components/Dashboard/NutritionRequirementsForm.js
@@ -1,4 +1,7 @@
 /**
+ * @fileoverview NutritionRequirementsForm component
+ */
+/**
  * NutritionRequirementsForm.js
  * 
  * Component for inputting custom nutritional requirements.

--- a/frontend/src/components/Dashboard/OptimizedMealPlanDisplay.js
+++ b/frontend/src/components/Dashboard/OptimizedMealPlanDisplay.js
@@ -1,4 +1,7 @@
 /**
+ * @fileoverview OptimizedMealPlanDisplay component
+ */
+/**
  * OptimizedMealPlanDisplay.js
  * 
  * Component to display the results of an optimized meal plan.

--- a/frontend/src/components/Dashboard/Recommendations.js
+++ b/frontend/src/components/Dashboard/Recommendations.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview Recommendations component
+ */
 // src/components/Dashboard/Recommendations.js
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -5,6 +8,11 @@ import { Box, Grid, Typography } from '@mui/material';
 import RestaurantCard from './RestaurantCard'; // Import the Tailwind-styled card
 // Removed useTheme and style constants/functions
 
+/**
+ * Recommendations component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 const Recommendations = React.memo(({ restaurants }) => {
     // Removed theme = useTheme()
 

--- a/frontend/src/components/Dashboard/RestaurantCard.js
+++ b/frontend/src/components/Dashboard/RestaurantCard.js
@@ -1,9 +1,17 @@
 /**
+ * @fileoverview RestaurantCard component
+ */
+/**
  * Compact restaurant card with border‑elevation substitute.
  */
 import React from 'react';
 import { Card, CardContent, Typography, CardMedia } from '@mui/material';
 
+/**
+ * RestaurantCard component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function RestaurantCard({ restaurant, source }) {
   return (
     <Card

--- a/frontend/src/components/Dashboard/WelcomeBanner.js
+++ b/frontend/src/components/Dashboard/WelcomeBanner.js
@@ -1,9 +1,17 @@
+/**
+ * @fileoverview WelcomeBanner component
+ */
 // src/components/Dashboard/WelcomeBanner.js
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Box, Typography } from '@mui/material';
 // Removed useTheme and style constants/functions
 
+/**
+ * WelcomeBanner component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 const WelcomeBanner = React.memo(({ userName }) => {
     // Removed theme = useTheme()
     const [greeting, setGreeting] = useState('Hello');

--- a/frontend/src/components/Dashboard/store.js
+++ b/frontend/src/components/Dashboard/store.js
@@ -1,4 +1,7 @@
 /**
+ * @fileoverview store component
+ */
+/**
  * Lightweight global store (Zustand) — eliminates prop‑drilling.
  * • Named import (`{ create }`) plays nicely with ESM bundlers.
  * • toggleDrawer uses previous state correctly.

--- a/frontend/src/components/Footer/Simple Info/CopyWright/index.js
+++ b/frontend/src/components/Footer/Simple Info/CopyWright/index.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview index component
+ */
 // components/Footer/Simple Info/CopyWright/index.js
 import React from 'react';
 // Removed unused imports: useEffect, useState, gql, useQuery

--- a/frontend/src/components/HeroSection.js
+++ b/frontend/src/components/HeroSection.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview HeroSection component
+ */
 // components/HeroSection.js
 /**
  * @fileoverview The hero section for FineDinning landing page
@@ -9,6 +12,11 @@ import { Box, Typography } from '@mui/material';
 /**
  * HeroSection - Displays the FineDinning logo & tagline
  * @returns {JSX.Element} The hero/branding portion of the page
+ */
+/**
+ * HeroSection component
+ * @param {object} props
+ * @returns {JSX.Element}
  */
 export default function HeroSection() {
     return (

--- a/frontend/src/components/LoginForm.js
+++ b/frontend/src/components/LoginForm.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview LoginForm component
+ */
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
 import { Box, TextField, Button, Link, Typography, CircularProgress } from '@mui/material';

--- a/frontend/src/components/MealPlanViewer.js
+++ b/frontend/src/components/MealPlanViewer.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview MealPlanViewer component
+ */
 import React from 'react';
 import {
   Card,

--- a/frontend/src/components/Profile/AvatarUpload.js
+++ b/frontend/src/components/Profile/AvatarUpload.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview AvatarUpload component
+ */
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { Avatar, Box } from '@mui/material';
@@ -5,6 +8,11 @@ import { useDropzone } from 'react-dropzone';
 import imageCompression from 'browser-image-compression';
 import { generateInitialsAvatar } from '@/utils/avatar';
 
+/**
+ * AvatarUpload component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function AvatarUpload({ user, onUpload }) {
   const onDrop = useCallback(async (files) => {
     const file = files[0];

--- a/frontend/src/components/Profile/CalorieProgressRing.js
+++ b/frontend/src/components/Profile/CalorieProgressRing.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview CalorieProgressRing component
+ */
 import React, { useMemo } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import { Box } from '@mui/material';
@@ -12,6 +15,11 @@ const GET_STATS_BY_USER = gql`
   }
 `;
 
+/**
+ * CalorieProgressRing component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function CalorieProgressRing({ userId, dailyCalories = 0, consumed }) {
   const { data } = useQuery(GET_STATS_BY_USER, {
     variables: { userId },

--- a/frontend/src/components/Profile/EditableField.js
+++ b/frontend/src/components/Profile/EditableField.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview EditableField component
+ */
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Typography, TextField, IconButton } from '@mui/material';
@@ -27,6 +30,11 @@ async function updateField({ userId, field, value }) {
   return json.data.updateUser;
 }
 
+/**
+ * EditableField component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function EditableField({ label, field, value: initialValue, unit, userId, measurementSystem }) {
   const [editing, setEditing] = useState(false);
   const [value, setValue] = useState(initialValue ?? '');

--- a/frontend/src/components/Profile/ProfileDetailItem.js
+++ b/frontend/src/components/Profile/ProfileDetailItem.js
@@ -1,7 +1,15 @@
+/**
+ * @fileoverview ProfileDetailItem component
+ */
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Box, Tooltip, Typography } from '@mui/material';
 
+/**
+ * ProfileDetailItem component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function ProfileDetailItem({ icon, term, definition, tooltip }) {
   const content = (
     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>

--- a/frontend/src/components/Profile/ProfileDetails.js
+++ b/frontend/src/components/Profile/ProfileDetails.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview ProfileDetails component
+ */
 import React from 'react';
 import {Avatar, Box, Card, CardContent, Chip, Grid, Typography} from '@mui/material';
 import WorkIcon from '@mui/icons-material/Work';
@@ -11,6 +14,11 @@ import ProfileDetailItem from './ProfileDetailItem';
 import {generateInitialsAvatar} from '@/utils/avatar';
 import CalorieProgressRing from './CalorieProgressRing';
 
+/**
+ * ProfileDetails component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function ProfileDetails({user}) {
     if (!user) return null;
     const joinDate = new Date(user.createdAt).toLocaleDateString();

--- a/frontend/src/components/Profile/ProfileEditor.js
+++ b/frontend/src/components/Profile/ProfileEditor.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview ProfileEditor component
+ */
 import React, { useState } from 'react';
 import { gql, useMutation } from '@apollo/client';
 import { Box, TextField, Button } from '@mui/material';
@@ -13,6 +16,11 @@ const UPDATE_USER = gql`
   }
 `;
 
+/**
+ * ProfileEditor component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function ProfileEditor({ user }) {
   const [name, setName] = useState(user.name);
   const [updateUser] = useMutation(UPDATE_USER);

--- a/frontend/src/components/Questionnaire/QuestionnaireWizard.js
+++ b/frontend/src/components/Questionnaire/QuestionnaireWizard.js
@@ -1,3 +1,6 @@
+/**
+ * @fileoverview QuestionnaireWizard component
+ */
 import React, {
   useState,
   useEffect,
@@ -247,6 +250,11 @@ const SummaryStep = ({ data, onBack }) => {
 SummaryStep.propTypes = { data: PropTypes.object.isRequired, onBack: PropTypes.func.isRequired };
 
 // Wizard container ----------------------------------------------------------
+/**
+ * QuestionnaireWizard component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function QuestionnaireWizard() {
   const [activeStep, setActiveStep] = useSessionState('wizardStep', 0);
   const [formData, setFormData] = useSessionState('wizardData', {});

--- a/frontend/src/components/ThemeToggle.js
+++ b/frontend/src/components/ThemeToggle.js
@@ -1,9 +1,17 @@
+/**
+ * @fileoverview ThemeToggle component
+ */
 import React from 'react';
 import { ToggleButtonGroup, ToggleButton } from '@mui/material';
 import LightModeIcon from '@mui/icons-material/LightMode';
 import DarkModeIcon from '@mui/icons-material/DarkMode';
 import { useThemePreference } from '../context/ThemePreferenceContext';
 
+/**
+ * ThemeToggle component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function ThemeToggle(props) {
     const { mode, setMode } = useThemePreference();
 

--- a/frontend/src/components/ToastStack.js
+++ b/frontend/src/components/ToastStack.js
@@ -1,7 +1,15 @@
+/**
+ * @fileoverview ToastStack component
+ */
 import React, { useEffect } from 'react';
 import { Transition } from '@headlessui/react';
 import { useToastStore } from '../store/toastStore';
 
+/**
+ * ToastStack component
+ * @param {object} props
+ * @returns {JSX.Element}
+ */
 export default function ToastStack() {
   const toasts = useToastStore(s => s.toasts);
   const removeToast = useToastStore(s => s.removeToast);


### PR DESCRIPTION
## Summary
- document every component under `frontend/src/components` with a file-level JSDoc header
- insert basic JSDoc for props on exported components

## Testing
- `CI=true npx next lint` *(fails: request to https://registry.npmjs.org/next failed)*