### PR TITLE
Add quick access to Canva designs

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -13,6 +13,12 @@
 
 > **Note**: This repository contains the frontend portion and is in active development. Features and documentation will evolve over time.
 
+### Quick Access
+- [Canva Design 1](https://www.canva.com/design/DAGb9hD06yg/OBGfzJ5Tc3A1LDYlEH0Msw/view?mode=prototype)
+- [Canva Design 2](https://www.canva.com/design/DAGb9gj3T0A/gShpCjKK3pJla-BF_2VNvw/view?mode=prototype)
+
+> **Contributors:** Please align new or updated components with these designs to ensure a consistent user experience.
+
 ---
 
 ## Table of Contents


### PR DESCRIPTION
## Summary
- link to Canva design prototypes at the top of the frontend README
- remind contributors to align components with those designs

## Testing
- `npm run lint` *(fails: `next` not found)*