### PR TITLE
Add in-memory MongoDB script for tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ file is present, printing the resulting restaurant list as JSON.
 * End-to-end & component tests: `npm run test:playwright`
 * Component tests only: `npm run test:components`
 * Unit tests via Node's test runner: `npm test` (see [docs/node_testing_setup.md](docs/node_testing_setup.md))
+* If MongoDB is not installed locally start `npm run dev:memory` in another terminal before running Playwright tests.
 * For detailed component testing guidance, refer to `frontend/docs/testing/component-testing.md`.
 
 ## Documentation
@@ -137,6 +138,7 @@ file is present, printing the resulting restaurant list as JSON.
 
 ## Available Scripts (Frontend - from `package.json`)
 * `npm run dev`: Starts the Next.js development server.
+* `npm run dev:memory`: Starts the dev server with an in-memory MongoDB for testing.
 * `npm run build`: Builds the Next.js application for production.
 * `npm run build:gpu`: Builds the application with GPU support.
 * `npm start`: Starts the Next.js production server.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -83,3 +83,15 @@ The pipeline fetches menu items, normalizes them, and writes
 `data/processed/restaurant_meals_processed.csv`. Progress messages are printed
 to the console. No additional environment variables are required beyond those
 defined earlier.
+
+## Running Tests with a Temporary Database
+
+The Playwright tests expect a MongoDB connection. If you do not have MongoDB
+installed locally you can start a disposable in-memory instance together with
+the Next.js dev server:
+
+```bash
+npm run dev:memory
+```
+
+Run your Playwright tests in another terminal once the server is ready.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "test:components": "cross-env NODE_ENV=test-ct playwright test --config=playwright-ct.config.js",
     "test:solver": "node --test src/tests/solver/concurrency.test.js",
     "seed": "node src/lib/HiGHS/seed_database.mjs",
+    "dev:memory": "node scripts/dev-memory.mjs",
     "codegen": "graphql-codegen --config codegen.yml",
     "benchmark:gpu": "node src/gpu/benchmark.mjs 1024"
   },
@@ -65,6 +66,7 @@
     "@graphql-codegen/cli": "^5.0.5",
     "@graphql-codegen/client-preset": "^4.8.0",
     "@playwright/test": "^1.52.0",
+    "mongodb-memory-server": "^8.14.0",
     "@tailwindcss/postcss": "^4.1.6",
     "cross-env": "^7.0.3",
     "eslint": "^9.26.0",

--- a/frontend/playwright-ct.config.js
+++ b/frontend/playwright-ct.config.js
@@ -33,7 +33,7 @@ export default defineConfig({
 
   // Add this block for the component development server
   ctDevServer: {
-    command: 'npm run dev', // Uses 'next dev' from your package.json
+    command: 'npm run dev:memory', // Start dev server with in-memory MongoDB
     port: 3000,             // The port your Next.js app runs on
     reuseExistingServer: !process.env.CI, // Reuse dev server locally, but not on CI
     env: { NODE_ENV: 'test-ct' },

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,5 +1,5 @@
 // playwright.config.js
-import { defineConfig } from '@playwright/experimental-ct-react';
+import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
     testDir: 'src/tests',
@@ -9,7 +9,7 @@ export default defineConfig({
     },
     ct: {
       devServer: {
-        command: 'npm run dev',
+        command: 'npm run dev:memory',
         port: 3000,
         reuseExistingServer: true,
         env: { NODE_ENV: 'test-ct' },

--- a/frontend/scripts/dev-memory.mjs
+++ b/frontend/scripts/dev-memory.mjs
@@ -1,0 +1,20 @@
+import { MongoMemoryServer } from 'mongodb-memory-server';
+import { spawn } from 'child_process';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const mongod = await MongoMemoryServer.create();
+process.env.MONGODB_URI = mongod.getUri();
+console.log('Started in-memory MongoDB at', process.env.MONGODB_URI);
+
+const dev = spawn('npm', ['run', 'dev'], {
+  stdio: 'inherit',
+  shell: true,
+  env: { ...process.env, MONGODB_URI: process.env.MONGODB_URI }
+});
+
+dev.on('exit', async (code) => {
+  await mongod.stop();
+  process.exit(code);
+});


### PR DESCRIPTION
## Summary
- document how to run the Playwright tests without a local MongoDB instance
- add `dev:memory` script using mongodb-memory-server
- use the new script for Playwright config

## Testing
- `npm test`
- `npm run test:components` *(fails: mount errors)*
- `npm run test:playwright` *(fails: Playwright run error)*