### PR TITLE
[codex] Login recovery operator feedback

### DIFF
--- a/frontend/src/context/authUtils.ts
+++ b/frontend/src/context/authUtils.ts
@@ -1,0 +1,604 @@
+// @ts-nocheck
+import storage from '@/utils/storage';
+
+export class AuthTokenValidationError extends Error {
+    constructor(code, message) {
+        super(message);
+        this.name = 'AuthTokenValidationError';
+        this.code = code;
+    }
+}
+
+export class AuthSessionStorageError extends Error {
+    constructor(code, message) {
+        super(message);
+        this.name = 'AuthSessionStorageError';
+        this.code = code;
+    }
+}
+
+export class AuthSignupValidationError extends Error {
+    constructor(code, message) {
+        super(message);
+        this.name = 'AuthSignupValidationError';
+        this.code = code;
+    }
+}
+
+export class AuthLoginValidationError extends Error {
+    constructor(code, message) {
+        super(message);
+        this.name = 'AuthLoginValidationError';
+        this.code = code;
+    }
+}
+
+const AUTH_TOKEN_ERROR_MESSAGES = {
+    missing: 'Your session is no longer available. Please sign in again.',
+    malformed: 'Your session is no longer valid. Please sign in again.',
+    invalidPayload: 'Your session is no longer valid. Please sign in again.',
+    expired: 'Your session has expired. Please sign in again.',
+};
+
+const AUTH_SESSION_ERROR_MESSAGES = {
+    storageUnavailable: 'Unable to save your session. Please try again.',
+};
+
+const AUTH_STORED_SESSION_ERROR_MESSAGE = 'Your saved session could not be read. Please sign in again.';
+
+const AUTH_LOGIN_ERROR_MESSAGES = {
+    invalidPayload: 'Please enter your email address and password.',
+    missingEmail: 'Please enter your email address.',
+    invalidEmail: 'Please enter a valid email address.',
+    missingPassword: 'Please enter your password.',
+};
+
+const AUTH_LOGIN_RECOVERY_MESSAGE = 'Login failed. Please check your email and password.';
+const AUTH_LOGIN_SAFE_ERROR_MESSAGES = new Map([
+    ['invalid credentials', 'Invalid credentials'],
+    ['email and password are required.', AUTH_LOGIN_ERROR_MESSAGES.invalidPayload],
+    ['please enter your email address.', AUTH_LOGIN_ERROR_MESSAGES.missingEmail],
+    ['please enter a valid email address.', AUTH_LOGIN_ERROR_MESSAGES.invalidEmail],
+    ['please enter your password.', AUTH_LOGIN_ERROR_MESSAGES.missingPassword],
+    [
+        'too many login attempts from this ip. please try again in 15 minutes.',
+        'Too many login attempts from this IP. Please try again in 15 minutes.',
+    ],
+    [
+        'too many login attempts for this account. please try again in 15 minutes.',
+        'Too many login attempts for this account. Please try again in 15 minutes.',
+    ],
+]);
+
+const AUTH_SIGNUP_ERROR_MESSAGES = {
+    invalidPayload: 'Please review the signup details and try again.',
+    missingName: 'Please enter your name.',
+    missingEmail: 'Please enter your email address.',
+    invalidEmail: 'Please enter a valid email address.',
+    missingPassword: 'Please enter a password.',
+    weakPasswordLength: 'Password must be at least 8 characters long.',
+    weakPasswordUppercase: 'Password must contain at least one uppercase letter.',
+    weakPasswordLowercase: 'Password must contain at least one lowercase letter.',
+    weakPasswordNumber: 'Password must contain at least one number.',
+    weakPasswordSymbol: 'Password must contain at least one special character.',
+    missingGender: 'Please select a gender.',
+    invalidGender: 'Please choose a valid gender.',
+    missingMeasurementSystem: 'Please select a measurement system.',
+    invalidMeasurementSystem: 'Please choose a valid measurement system.',
+    invalidWeightGoal: 'Please choose a valid weight goal.',
+    invalidDailyCalories: 'Please enter a valid daily calorie target.',
+};
+
+const SIGNUP_EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const SIGNUP_ALLOWED_GENDERS = new Set(['MALE', 'FEMALE', 'OTHER']);
+const SIGNUP_ALLOWED_MEASUREMENT_SYSTEMS = new Set(['METRIC', 'IMPERIAL']);
+const SIGNUP_ALLOWED_WEIGHT_GOALS = new Set(['LOSE', 'GAIN', 'MAINTAIN']);
+
+const AUTH_FEEDBACK_MIN_HEIGHT = 56;
+const AUTH_FEEDBACK_SURFACE_STYLES = {
+    error: {
+        bgcolor: 'rgba(244, 67, 54, 0.08)',
+        border: '1px solid rgba(244, 67, 54, 0.2)',
+    },
+    success: {
+        bgcolor: 'rgba(76, 175, 80, 0.08)',
+        border: '1px solid rgba(76, 175, 80, 0.2)',
+    },
+    neutral: {
+        bgcolor: 'transparent',
+        border: '1px solid transparent',
+    },
+};
+
+const createAuthTokenValidationError = (code) => {
+    const message = AUTH_TOKEN_ERROR_MESSAGES[code] || AUTH_TOKEN_ERROR_MESSAGES.malformed;
+    return new AuthTokenValidationError(code, message);
+};
+
+const createAuthSessionStorageError = (code) => {
+    const message = AUTH_SESSION_ERROR_MESSAGES[code] || AUTH_SESSION_ERROR_MESSAGES.storageUnavailable;
+    return new AuthSessionStorageError(code, message);
+};
+
+const createAuthLoginValidationError = (code) => {
+    const message = AUTH_LOGIN_ERROR_MESSAGES[code] || AUTH_LOGIN_ERROR_MESSAGES.invalidPayload;
+    return new AuthLoginValidationError(code, message);
+};
+
+export function getLoginErrorMessage(message) {
+    if (typeof message !== 'string') {
+        return AUTH_LOGIN_RECOVERY_MESSAGE;
+    }
+
+    const normalizedMessage = message.replace(/^(GraphQL|Network) error:\s*/i, '').trim();
+
+    if (!normalizedMessage) {
+        return AUTH_LOGIN_RECOVERY_MESSAGE;
+    }
+
+    const candidates = normalizedMessage
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+    for (const candidate of candidates) {
+        const safeMessage = AUTH_LOGIN_SAFE_ERROR_MESSAGES.get(candidate.toLowerCase());
+        if (safeMessage) {
+            return safeMessage;
+        }
+    }
+
+    return AUTH_LOGIN_RECOVERY_MESSAGE;
+}
+
+const createAuthSignupValidationError = (code) => {
+    const message = AUTH_SIGNUP_ERROR_MESSAGES[code] || AUTH_SIGNUP_ERROR_MESSAGES.invalidPayload;
+    return new AuthSignupValidationError(code, message);
+};
+
+const buildStoredAuthUserSnapshot = (userData) => {
+    const basicUserInfo = {
+        id: userData.id,
+        name: userData.name,
+        email: userData.email,
+        role: userData.role,
+        subscriptionPlan: userData.subscriptionPlan || 'FREE',
+        subscriptionStatus: userData.subscriptionStatus || 'inactive',
+    };
+
+    const dailyCalories = userData.dailyCalories;
+
+    return {
+        ...basicUserInfo,
+        ...(dailyCalories === undefined ? {} : { dailyCalories }),
+    };
+};
+
+export function parseStoredAuthUserSnapshot(storedUser) {
+    if (typeof storedUser !== 'string' || storedUser.trim() === '') {
+        return null;
+    }
+
+    try {
+        const parsedUser = JSON.parse(storedUser);
+
+        if (!parsedUser || typeof parsedUser !== 'object' || Array.isArray(parsedUser)) {
+            return null;
+        }
+
+        if (
+            typeof parsedUser.id !== 'string' ||
+            typeof parsedUser.name !== 'string' ||
+            typeof parsedUser.email !== 'string' ||
+            typeof parsedUser.role !== 'string'
+        ) {
+            return null;
+        }
+
+        return buildStoredAuthUserSnapshot(parsedUser);
+    } catch (error) {
+        return null;
+    }
+}
+
+export function resolveStoredAuthSession(storedToken, storedUser, nowSeconds = Math.floor(Date.now() / 1000)) {
+    const tokenValidation = validateStoredAuthToken(storedToken, nowSeconds);
+
+    if (!storedToken) {
+        return {
+            status: 'missing-token',
+            token: null,
+            user: null,
+            sessionNotice: storedUser ? AUTH_STORED_SESSION_ERROR_MESSAGE : '',
+            shouldClearStorage: true,
+            tokenValidation,
+        };
+    }
+
+    if (!tokenValidation.valid) {
+        return {
+            status: 'invalid-token',
+            token: null,
+            user: null,
+            sessionNotice: tokenValidation.error.message,
+            shouldClearStorage: true,
+            tokenValidation,
+        };
+    }
+
+    const storedUserSnapshot = parseStoredAuthUserSnapshot(storedUser);
+
+    if (!storedUserSnapshot) {
+        return {
+            status: 'invalid-user',
+            token: null,
+            user: null,
+            sessionNotice: AUTH_STORED_SESSION_ERROR_MESSAGE,
+            shouldClearStorage: true,
+            tokenValidation,
+        };
+    }
+
+    return {
+        status: 'hydrated',
+        token: storedToken,
+        user: storedUserSnapshot,
+        sessionNotice: '',
+        shouldClearStorage: false,
+        tokenValidation,
+    };
+}
+
+const decodeBase64Url = (value) => {
+    const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = '='.repeat((4 - (normalized.length % 4)) % 4);
+    const base64 = `${normalized}${padding}`;
+
+    if (typeof globalThis.atob === 'function') {
+        return globalThis.atob(base64);
+    }
+
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.from(base64, 'base64').toString('utf8');
+    }
+
+    throw new Error('Base64 decoding is not available in this environment.');
+};
+
+const validateSignupPassword = (password) => {
+    if (typeof password !== 'string' || password.trim() === '') {
+        return createAuthSignupValidationError('missingPassword');
+    }
+
+    if (password.length < 8) {
+        return createAuthSignupValidationError('weakPasswordLength');
+    }
+
+    if (!/[A-Z]/.test(password)) {
+        return createAuthSignupValidationError('weakPasswordUppercase');
+    }
+
+    if (!/[a-z]/.test(password)) {
+        return createAuthSignupValidationError('weakPasswordLowercase');
+    }
+
+    if (!/[0-9]/.test(password)) {
+        return createAuthSignupValidationError('weakPasswordNumber');
+    }
+
+    if (!/[^A-Za-z0-9]/.test(password)) {
+        return createAuthSignupValidationError('weakPasswordSymbol');
+    }
+
+    return null;
+};
+
+const normalizeSignupStringArray = (values) =>
+    values.map((value) => (typeof value === 'string' ? value.trim() : value)).filter((value) => value !== '');
+
+const hasOwnSignupField = (input, key) => Object.prototype.hasOwnProperty.call(input, key);
+
+export function validateStoredAuthToken(token, nowSeconds = Math.floor(Date.now() / 1000)) {
+    if (typeof token !== 'string' || token.trim() === '') {
+        return { valid: false, error: createAuthTokenValidationError('missing') };
+    }
+
+    const parts = token.split('.');
+    if (parts.length < 2) {
+        return { valid: false, error: createAuthTokenValidationError('malformed') };
+    }
+
+    try {
+        const payload = JSON.parse(decodeBase64Url(parts[1]));
+
+        if (!payload || typeof payload !== 'object') {
+            return { valid: false, error: createAuthTokenValidationError('invalidPayload') };
+        }
+
+        const expiresAt = Number(payload.exp);
+        if (!Number.isFinite(expiresAt)) {
+            return { valid: false, error: createAuthTokenValidationError('invalidPayload') };
+        }
+
+        if (expiresAt <= nowSeconds) {
+            return { valid: false, error: createAuthTokenValidationError('expired') };
+        }
+
+        return { valid: true, payload: { ...payload, exp: expiresAt } };
+    } catch (error) {
+        return { valid: false, error: createAuthTokenValidationError('invalidPayload') };
+    }
+}
+
+export function persistLoginInfo(token, userData, storageAdapter = storage, nowSeconds = Math.floor(Date.now() / 1000)) {
+    const tokenValidation = validateStoredAuthToken(token, nowSeconds);
+
+    if (!tokenValidation.valid) {
+        storageAdapter.removeItem('authToken');
+        storageAdapter.removeItem('userInfo');
+        return {
+            ok: false,
+            user: null,
+            error: tokenValidation.error,
+        };
+    }
+
+    const basicUserInfo = buildStoredAuthUserSnapshot(userData);
+    const tokenStored = storageAdapter.setItem('authToken', token);
+    const userStored = storageAdapter.setItem('userInfo', JSON.stringify(basicUserInfo));
+
+    if (!tokenStored || !userStored) {
+        storageAdapter.removeItem('authToken');
+        storageAdapter.removeItem('userInfo');
+        return {
+            ok: false,
+            user: null,
+            error: createAuthSessionStorageError('storageUnavailable'),
+        };
+    }
+
+    return {
+        ok: true,
+        user: basicUserInfo,
+        error: null,
+    };
+}
+
+export function saveLoginInfo(token, userData, nowSeconds = Math.floor(Date.now() / 1000)) {
+    const result = persistLoginInfo(token, userData, storage, nowSeconds);
+    return result.ok ? result.user : null;
+}
+
+export function completeSignupSession(sessionResult, { onSuccess, onError } = {}) {
+    if (!sessionResult?.ok) {
+        const message = sessionResult?.error?.message || AUTH_SESSION_ERROR_MESSAGES.storageUnavailable;
+        if (typeof onError === 'function') {
+            onError(message);
+        }
+        return false;
+    }
+
+    if (typeof onSuccess === 'function') {
+        onSuccess();
+    }
+
+    return true;
+}
+
+export function validateLoginInput(input) {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        return { valid: false, error: createAuthLoginValidationError('invalidPayload') };
+    }
+
+    const normalizedEmail = typeof input.email === 'string' ? input.email.trim().toLowerCase() : '';
+    if (!normalizedEmail) {
+        return { valid: false, error: createAuthLoginValidationError('missingEmail') };
+    }
+
+    if (!SIGNUP_EMAIL_REGEX.test(normalizedEmail)) {
+        return { valid: false, error: createAuthLoginValidationError('invalidEmail') };
+    }
+
+    if (typeof input.password !== 'string' || input.password.trim() === '') {
+        return { valid: false, error: createAuthLoginValidationError('missingPassword') };
+    }
+
+    return {
+        valid: true,
+        input: {
+            email: normalizedEmail,
+            password: input.password,
+        },
+    };
+}
+
+export function validateSignupInput(input) {
+    if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        return { valid: false, error: createAuthSignupValidationError('invalidPayload') };
+    }
+
+    const normalizedName = typeof input.name === 'string' ? input.name.trim() : '';
+    if (!normalizedName) {
+        return { valid: false, error: createAuthSignupValidationError('missingName') };
+    }
+
+    const normalizedEmail = typeof input.email === 'string' ? input.email.trim().toLowerCase() : '';
+    if (!normalizedEmail) {
+        return { valid: false, error: createAuthSignupValidationError('missingEmail') };
+    }
+
+    if (!SIGNUP_EMAIL_REGEX.test(normalizedEmail)) {
+        return { valid: false, error: createAuthSignupValidationError('invalidEmail') };
+    }
+
+    const passwordError = validateSignupPassword(input.password);
+    if (passwordError) {
+        return { valid: false, error: passwordError };
+    }
+
+    const normalizedGender = typeof input.gender === 'string' ? input.gender.trim().toUpperCase() : '';
+    if (!normalizedGender) {
+        return { valid: false, error: createAuthSignupValidationError('missingGender') };
+    }
+
+    if (!SIGNUP_ALLOWED_GENDERS.has(normalizedGender)) {
+        return { valid: false, error: createAuthSignupValidationError('invalidGender') };
+    }
+
+    const normalizedMeasurementSystem = typeof input.measurementSystem === 'string' ? input.measurementSystem.trim().toUpperCase() : '';
+    if (!normalizedMeasurementSystem) {
+        return { valid: false, error: createAuthSignupValidationError('missingMeasurementSystem') };
+    }
+
+    if (!SIGNUP_ALLOWED_MEASUREMENT_SYSTEMS.has(normalizedMeasurementSystem)) {
+        return { valid: false, error: createAuthSignupValidationError('invalidMeasurementSystem') };
+    }
+
+    const normalizedInput = {
+        name: normalizedName,
+        email: normalizedEmail,
+        gender: normalizedGender,
+        measurementSystem: normalizedMeasurementSystem,
+        password: input.password,
+    };
+
+    if (hasOwnSignupField(input, 'role')) {
+        normalizedInput.role = input.role;
+    }
+
+    if (hasOwnSignupField(input, 'weight')) {
+        normalizedInput.weight = input.weight;
+    }
+
+    if (hasOwnSignupField(input, 'height')) {
+        normalizedInput.height = input.height;
+    }
+
+    if (hasOwnSignupField(input, 'weightGoal')) {
+        normalizedInput.weightGoal = input.weightGoal;
+    }
+
+    if (hasOwnSignupField(input, 'foodGoals')) {
+        normalizedInput.foodGoals = input.foodGoals;
+    }
+
+    if (hasOwnSignupField(input, 'allergies')) {
+        normalizedInput.allergies = input.allergies;
+    }
+
+    if (hasOwnSignupField(input, 'dailyCalories')) {
+        normalizedInput.dailyCalories = input.dailyCalories;
+    }
+
+    if (normalizedInput.weightGoal === undefined || normalizedInput.weightGoal === null) {
+        delete normalizedInput.weightGoal;
+    } else if (typeof normalizedInput.weightGoal === 'string') {
+        const normalizedWeightGoal = normalizedInput.weightGoal.trim().toUpperCase();
+
+        if (!normalizedWeightGoal) {
+            delete normalizedInput.weightGoal;
+        } else if (!SIGNUP_ALLOWED_WEIGHT_GOALS.has(normalizedWeightGoal)) {
+            return { valid: false, error: createAuthSignupValidationError('invalidWeightGoal') };
+        } else {
+            normalizedInput.weightGoal = normalizedWeightGoal;
+        }
+    } else {
+        return { valid: false, error: createAuthSignupValidationError('invalidWeightGoal') };
+    }
+
+    if (normalizedInput.dailyCalories !== undefined && normalizedInput.dailyCalories !== null && normalizedInput.dailyCalories !== '') {
+        const normalizedDailyCalories = typeof normalizedInput.dailyCalories === 'number'
+            ? normalizedInput.dailyCalories
+            : Number(normalizedInput.dailyCalories);
+
+        if (!Number.isInteger(normalizedDailyCalories) || normalizedDailyCalories <= 0) {
+            return { valid: false, error: createAuthSignupValidationError('invalidDailyCalories') };
+        }
+
+        normalizedInput.dailyCalories = normalizedDailyCalories;
+    }
+
+    if (Array.isArray(normalizedInput.foodGoals)) {
+        normalizedInput.foodGoals = normalizeSignupStringArray(normalizedInput.foodGoals);
+    }
+
+    if (Array.isArray(normalizedInput.allergies)) {
+        normalizedInput.allergies = normalizeSignupStringArray(normalizedInput.allergies);
+    }
+
+    return { valid: true, input: normalizedInput };
+}
+
+export function buildAuthFeedbackState({
+    isLoading = false,
+    errorMessage = '',
+    sessionNotice = '',
+    successMessage = '',
+    emptyMessage = 'Ready to sign in.',
+    loadingMessage = 'Checking your session...',
+} = {}) {
+    if (isLoading) {
+        return {
+            state: 'loading',
+            message: loadingMessage,
+            role: 'status',
+            ariaLive: 'polite',
+            minHeight: AUTH_FEEDBACK_MIN_HEIGHT,
+            showSpinner: true,
+        };
+    }
+
+    if (errorMessage) {
+        return {
+            state: 'error',
+            message: errorMessage,
+            role: 'alert',
+            ariaLive: 'assertive',
+            minHeight: AUTH_FEEDBACK_MIN_HEIGHT,
+            showSpinner: false,
+        };
+    }
+
+    if (sessionNotice) {
+        return {
+            state: 'error',
+            message: sessionNotice,
+            role: 'alert',
+            ariaLive: 'assertive',
+            minHeight: AUTH_FEEDBACK_MIN_HEIGHT,
+            showSpinner: false,
+        };
+    }
+
+    if (successMessage) {
+        return {
+            state: 'success',
+            message: successMessage,
+            role: 'status',
+            ariaLive: 'polite',
+            minHeight: AUTH_FEEDBACK_MIN_HEIGHT,
+            showSpinner: false,
+        };
+    }
+
+    return {
+        state: 'empty',
+        message: emptyMessage,
+        role: 'status',
+        ariaLive: 'polite',
+        minHeight: AUTH_FEEDBACK_MIN_HEIGHT,
+        showSpinner: false,
+    };
+}
+
+export function buildAuthFeedbackContainerStyles(state = 'empty') {
+    if (state === 'error') {
+        return AUTH_FEEDBACK_SURFACE_STYLES.error;
+    }
+
+    if (state === 'success') {
+        return AUTH_FEEDBACK_SURFACE_STYLES.success;
+    }
+
+    return AUTH_FEEDBACK_SURFACE_STYLES.neutral;
+}

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,0 +1,252 @@
+// @ts-nocheck
+import { gql } from '@apollo/client';
+import { useMutation } from '@apollo/client/react';
+import PersonIcon from '@mui/icons-material/Person';
+import ShieldIcon from '@mui/icons-material/Shield';
+import { 
+    Box, 
+    Button, 
+    TextField, 
+    Typography, 
+    Container, 
+    Paper, 
+    CircularProgress,
+    Divider
+} from '@mui/material';
+import Head from 'next/head';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import React, { useState, useEffect } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import {
+    buildAuthFeedbackContainerStyles,
+    buildAuthFeedbackState,
+    getLoginErrorMessage,
+    validateLoginInput,
+} from '@/context/authUtils';
+
+const LOGIN_MUTATION = gql`
+  mutation LoginUser($email: String!, $password: String!) {
+    loginUser(email: $email, password: $password) {
+      token
+        user {
+        id
+        name
+        email
+        role
+        subscriptionPlan
+        subscriptionStatus
+      }
+    }
+  }
+`;
+
+const isDev = process.env.NODE_ENV === 'development';
+
+export default function LoginPage() {
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [error, setError] = useState('');
+    const [successMessage, setSuccessMessage] = useState('');
+    const [devLoading, setDevLoading] = useState(false);
+    const { login, isAuthenticated, user, loading: authLoading, sessionNotice } = useAuth();
+    const router = useRouter();
+
+    const [loginUserMutation, { loading: mutationLoading }] = useMutation(LOGIN_MUTATION, {
+        onCompleted: (data) => {
+            const { token, user } = data.loginUser;
+            const sessionResult = login(token, user);
+            if (!sessionResult?.ok) {
+                setError(sessionResult?.error?.message || 'Unable to save your session. Please try again.');
+                setSuccessMessage('');
+                return;
+            }
+            setError('');
+            setSuccessMessage(`Signed in. Redirecting to your ${user.role === 'ADMIN' ? 'admin' : 'dashboard'}...`);
+        },
+        onError: (err) => {
+            setError(getLoginErrorMessage(err?.message));
+            setSuccessMessage('');
+        }
+    });
+
+    const feedback = buildAuthFeedbackState({
+        isLoading: authLoading,
+        errorMessage: error,
+        sessionNotice,
+        successMessage,
+    });
+    const feedbackSurfaceStyles = buildAuthFeedbackContainerStyles(feedback.state);
+    const isBusy = authLoading || mutationLoading || devLoading;
+
+    useEffect(() => {
+        if (isAuthenticated && user) {
+            if (user.role === 'ADMIN') {
+                router.push('/admin').catch(() => {});
+            } else {
+                router.push('/dashboard').catch(() => {});
+            }
+        }
+    }, [isAuthenticated, user, router]);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setError('');
+        setSuccessMessage('');
+        const validation = validateLoginInput({ email, password });
+        if (!validation.valid) {
+            setError(validation.error.message);
+            return;
+        }
+        try {
+            await loginUserMutation({ variables: validation.input });
+        } catch (err) {
+            // Error is handled by onError callback
+        }
+    };
+
+    const handleDevLogin = async (role) => {
+        setError('');
+        setSuccessMessage('');
+        setDevLoading(true);
+        try {
+            const res = await fetch('/api/dev-login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ role }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+                setError(data.error || 'Dev login failed.');
+                return;
+            }
+            const sessionResult = login(data.token, data.user);
+            if (!sessionResult?.ok) {
+                setError(sessionResult?.error?.message || 'Unable to save your session. Please try again.');
+                return;
+            }
+            setSuccessMessage(`Signed in. Redirecting to your ${data.user.role === 'ADMIN' ? 'admin' : 'dashboard'}...`);
+        } catch (err) {
+            setError('Dev login request failed.');
+        } finally {
+            setDevLoading(false);
+        }
+    };
+
+    return (
+        <Container maxWidth="xs">
+            <Head>
+                <title>Login - Secure Access</title>
+            </Head>
+            <Box sx={{ mt: 8, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+                <Paper elevation={3} sx={{ p: 4, width: '100%', borderRadius: 2 }}>
+                    <Typography component="h1" variant="h5" align="center" gutterBottom>
+                        Secure Login
+                    </Typography>
+                    <Box
+                        id="auth-feedback"
+                        role={feedback.role}
+                        aria-live={feedback.ariaLive}
+                        aria-atomic="true"
+                        sx={{
+                            minHeight: feedback.minHeight,
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 1.5,
+                            mb: 2,
+                            px: 1.5,
+                            py: 1,
+                            borderRadius: 1.5,
+                            ...feedbackSurfaceStyles,
+                        }}
+                    >
+                        {feedback.showSpinner && <CircularProgress size={18} />}
+                        <Typography
+                            variant="body2"
+                            sx={{
+                                color: feedback.state === 'error' ? 'error.main' : feedback.state === 'success' ? 'success.main' : 'text.secondary',
+                                fontWeight: feedback.state === 'success' ? 700 : 400,
+                            }}
+                        >
+                            {feedback.message}
+                        </Typography>
+                    </Box>
+                    <Box component="form" onSubmit={handleSubmit} noValidate aria-busy={isBusy}>
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            id="email"
+                            label="Email Address"
+                            name="email"
+                            autoComplete="email"
+                            autoFocus
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            disabled={isBusy}
+                        />
+                        <TextField
+                            margin="normal"
+                            required
+                            fullWidth
+                            name="password"
+                            label="Password"
+                            type="password"
+                            id="password"
+                            autoComplete="current-password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            disabled={isBusy}
+                        />
+                        <Button
+                            type="submit"
+                            fullWidth
+                            variant="contained"
+                            sx={{ mt: 3, mb: 2, py: 1.5 }}
+                            disabled={isBusy}
+                        >
+                            {mutationLoading ? <CircularProgress size={24} color="inherit" /> : 'Sign In'}
+                        </Button>
+                    </Box>
+                    <Typography sx={{ color: 'text.secondary', mt: 2, textAlign: 'center' }}>
+                        New to Fine Dining?{' '}
+                        <Link href="/signup" style={{ color: '#F08E5D', fontWeight: 700 }}>
+                            Create an account
+                        </Link>
+                    </Typography>
+
+                    {isDev && (
+                        <>
+                            <Divider sx={{ my: 2 }}>Dev Quick Login</Divider>
+                            <Box sx={{ display: 'flex', gap: 2 }}>
+                                <Button
+                                    fullWidth
+                                    variant="outlined"
+                                    color="error"
+                                    startIcon={<ShieldIcon />}
+                                    onClick={() => handleDevLogin('admin')}
+                                    disabled={devLoading}
+                                >
+                                    Admin
+                                </Button>
+                                <Button
+                                    fullWidth
+                                    variant="outlined"
+                                    color="info"
+                                    startIcon={<PersonIcon />}
+                                    onClick={() => handleDevLogin('user')}
+                                    disabled={devLoading}
+                                >
+                                    User
+                                </Button>
+                            </Box>
+                        </>
+                    )}
+                </Paper>
+                <Typography variant="body2" color="text.secondary" align="center" sx={{ mt: 4 }}>
+                    Fine Dining © {new Date().getFullYear()}
+                </Typography>
+            </Box>
+        </Container>
+    );
+}

--- a/frontend/src/pages/signup.tsx
+++ b/frontend/src/pages/signup.tsx
@@ -1,0 +1,229 @@
+// @ts-nocheck
+import { gql } from '@apollo/client';
+import { useMutation } from '@apollo/client/react';
+import ArrowForwardRoundedIcon from '@mui/icons-material/ArrowForwardRounded';
+import RestaurantMenuRoundedIcon from '@mui/icons-material/RestaurantMenuRounded';
+import {
+    Box,
+    Button,
+    Container,
+    CircularProgress,
+    Grid,
+    Link,
+    MenuItem,
+    Paper,
+    TextField,
+    Typography,
+} from '@mui/material';
+import Head from 'next/head';
+import NextLink from 'next/link';
+import { useRouter } from 'next/router';
+import React, { useEffect, useState } from 'react';
+import { useAuth } from '@/context/AuthContext';
+import {
+    buildAuthFeedbackContainerStyles,
+    buildAuthFeedbackState,
+    completeSignupSession,
+    validateSignupInput,
+} from '@/context/authUtils';
+
+const REGISTER_USER = gql`
+    mutation RegisterUser($input: CreateUserInput!) {
+        registerUser(input: $input) {
+            token
+            user {
+                id
+                name
+                email
+                role
+                subscriptionPlan
+                subscriptionStatus
+            }
+        }
+    }
+`;
+
+export default function SignupPage() {
+    const router = useRouter();
+    const { login } = useAuth();
+    const [form, setForm] = useState({
+        name: '',
+        email: '',
+        password: '',
+        gender: 'OTHER',
+        measurementSystem: 'IMPERIAL',
+        weightGoal: 'MAINTAIN',
+        dailyCalories: 2200,
+    });
+    const [error, setError] = useState('');
+    const [successMessage, setSuccessMessage] = useState('');
+    const [registerUser, { loading }] = useMutation(REGISTER_USER, {
+        onCompleted: (data) => {
+            const sessionResult = login(data.registerUser.token, data.registerUser.user);
+            const sessionCommitted = completeSignupSession(sessionResult, {
+                onSuccess: () => {
+                    setSuccessMessage('Account created. Redirecting to onboarding...');
+                },
+                onError: setError,
+            });
+
+            if (!sessionCommitted) {
+                return;
+            }
+        },
+        onError: (err) => setError(err.message),
+    });
+
+    useEffect(() => {
+        if (!successMessage) {
+            return;
+        }
+
+        const redirectTimer = setTimeout(() => {
+            router.push('/onboarding').catch(() => {});
+        }, 0);
+
+        return () => clearTimeout(redirectTimer);
+    }, [router, successMessage]);
+
+    const update = (key) => (event) => {
+        const value = key === 'dailyCalories' ? Number(event.target.value) : event.target.value;
+        setForm((current) => ({ ...current, [key]: value }));
+    };
+
+    const submit = async (event) => {
+        event.preventDefault();
+        setError('');
+        setSuccessMessage('');
+        const validation = validateSignupInput(form);
+        if (!validation.valid) {
+            setError(validation.error.message);
+            return;
+        }
+
+        await registerUser({ variables: { input: validation.input } });
+    };
+
+    const feedback = buildAuthFeedbackState({
+        isLoading: loading,
+        errorMessage: error,
+        successMessage,
+        emptyMessage: 'Complete your account details to continue.',
+        loadingMessage: 'Creating your account...',
+    });
+    const feedbackSurfaceStyles = buildAuthFeedbackContainerStyles(feedback.state);
+
+    return (
+        <>
+            <Head><title>Create account - Fine Dining</title></Head>
+            <Box sx={{ minHeight: '100vh', bgcolor: '#14110F', color: '#fff', py: { xs: 4, md: 8 } }}>
+                <Container maxWidth="lg">
+                    <Grid container spacing={5} alignItems="center">
+                        <Grid item xs={12} md={6}>
+                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, mb: 5 }}>
+                                <RestaurantMenuRoundedIcon sx={{ color: '#F08E5D' }} />
+                                <Typography sx={{ color: '#F08E5D', fontWeight: 800, letterSpacing: '0.03em' }}>
+                                    fine dining
+                                </Typography>
+                            </Box>
+                            <Typography sx={{ fontSize: { xs: '2.4rem', md: '4.4rem' }, lineHeight: 1, fontWeight: 800, maxWidth: 620 }}>
+                                Build a diet system around your real life.
+                            </Typography>
+                            <Typography sx={{ mt: 3, color: 'rgba(255,255,255,0.68)', fontSize: '1.12rem', maxWidth: 560, lineHeight: 1.7 }}>
+                                Create your account, set nutrition goals, save recipes, generate plans, track macros, manage groceries, and upgrade when your needs grow.
+                            </Typography>
+                            <Grid container spacing={2} sx={{ mt: 4 }}>
+                                {['Meal planning', 'Macro logs', 'Pantry tools', 'Tier limits'].map((item) => (
+                                    <Grid item xs={6} key={item}>
+                                        <Box sx={{ p: 2, border: '1px solid rgba(255,255,255,0.08)', borderRadius: 2, bgcolor: 'rgba(255,255,255,0.03)' }}>
+                                            <Typography sx={{ fontWeight: 700 }}>{item}</Typography>
+                                        </Box>
+                                    </Grid>
+                                ))}
+                            </Grid>
+                        </Grid>
+                        <Grid item xs={12} md={6}>
+                            <Paper sx={{ p: { xs: 3, md: 4 }, bgcolor: '#1C1815', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 3 }}>
+                                <Typography variant="h4" sx={{ color: '#fff', fontWeight: 800, mb: 1 }}>Create account</Typography>
+                                <Typography sx={{ color: 'rgba(255,255,255,0.72)', mb: 3 }}>Free accounts start with basic planning limits.</Typography>
+                                <Box
+                                    id="signup-feedback"
+                                    role={feedback.role}
+                                    aria-live={feedback.ariaLive}
+                                    aria-atomic="true"
+                                    sx={{
+                                        minHeight: feedback.minHeight,
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: 1.5,
+                                        mb: 2,
+                                        px: 1.5,
+                                        py: 1,
+                                        borderRadius: 1.5,
+                                        ...feedbackSurfaceStyles,
+                                    }}
+                                >
+                                    {feedback.showSpinner && <CircularProgress size={18} />}
+                                    <Typography
+                                        variant="body2"
+                                        sx={{
+                                            color: feedback.state === 'error' ? 'error.main' : feedback.state === 'success' ? 'success.main' : 'text.secondary',
+                                            fontWeight: feedback.state === 'success' ? 700 : 400,
+                                        }}
+                                    >
+                                        {feedback.message}
+                                    </Typography>
+                                </Box>
+                                <Box component="form" onSubmit={submit} noValidate aria-busy={loading}>
+                                    <TextField fullWidth required label="Name" value={form.name} onChange={update('name')} margin="normal" disabled={loading} />
+                                    <TextField fullWidth required label="Email" type="email" value={form.email} onChange={update('email')} margin="normal" disabled={loading} />
+                                    <TextField fullWidth required label="Password" type="password" value={form.password} onChange={update('password')} margin="normal" helperText="Use 8+ chars with uppercase, lowercase, number, and symbol." disabled={loading} />
+                                    <Grid container spacing={2}>
+                                        <Grid item xs={12} sm={6}>
+                                            <TextField select fullWidth label="Goal" value={form.weightGoal} onChange={update('weightGoal')} margin="normal" disabled={loading}>
+                                                <MenuItem value="LOSE">Lose weight</MenuItem>
+                                                <MenuItem value="MAINTAIN">Maintain</MenuItem>
+                                                <MenuItem value="GAIN">Gain weight</MenuItem>
+                                            </TextField>
+                                        </Grid>
+                                        <Grid item xs={12} sm={6}>
+                                            <TextField fullWidth label="Daily calories" type="number" value={form.dailyCalories} onChange={update('dailyCalories')} margin="normal" disabled={loading} />
+                                        </Grid>
+                                        <Grid item xs={12} sm={6}>
+                                            <TextField select fullWidth label="Measurement" value={form.measurementSystem} onChange={update('measurementSystem')} margin="normal" disabled={loading}>
+                                                <MenuItem value="IMPERIAL">Imperial</MenuItem>
+                                                <MenuItem value="METRIC">Metric</MenuItem>
+                                            </TextField>
+                                        </Grid>
+                                        <Grid item xs={12} sm={6}>
+                                            <TextField select fullWidth label="Gender" value={form.gender} onChange={update('gender')} margin="normal" disabled={loading}>
+                                                <MenuItem value="FEMALE">Female</MenuItem>
+                                                <MenuItem value="MALE">Male</MenuItem>
+                                                <MenuItem value="OTHER">Other</MenuItem>
+                                            </TextField>
+                                        </Grid>
+                                    </Grid>
+                                    <Button
+                                        type="submit"
+                                        fullWidth
+                                        variant="contained"
+                                        size="large"
+                                        endIcon={loading ? undefined : <ArrowForwardRoundedIcon />}
+                                        disabled={loading}
+                                        sx={{ mt: 3, py: 1.4 }}
+                                    >
+                                        {loading ? <CircularProgress size={24} color="inherit" /> : 'Create free account'}
+                                    </Button>
+                                </Box>
+                                <Typography sx={{ mt: 3, color: 'rgba(255,255,255,0.72)' }}>
+                                    Already have an account?{' '}
+                                    <Link component={NextLink} href="/login" sx={{ color: '#F08E5D', fontWeight: 700 }}>Sign in</Link>
+                                </Typography>
+                            </Paper>
+                        </Grid>
+                    </Grid>
+                </Container>
+            </Box>
+        </>
+    );
+}

--- a/frontend/src/tests/unit/auth-security.login-recovery.operator-feedback.test.ts
+++ b/frontend/src/tests/unit/auth-security.login-recovery.operator-feedback.test.ts
@@ -1,0 +1,91 @@
+// @ts-nocheck
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildAuthFeedbackContainerStyles,
+    buildAuthFeedbackState,
+} from '../../context/authUtils';
+
+test('buildAuthFeedbackState exposes login operator feedback states with stable layout spacing', () => {
+    assert.deepEqual(
+        buildAuthFeedbackState({
+            isLoading: true,
+            emptyMessage: 'Ready to sign in.',
+            loadingMessage: 'Checking your credentials...',
+            successMessage: 'Signed in. Redirecting to your dashboard...',
+            errorMessage: 'Login failed. Please check your email and password.',
+        }),
+        {
+            state: 'loading',
+            message: 'Checking your credentials...',
+            role: 'status',
+            ariaLive: 'polite',
+            minHeight: 56,
+            showSpinner: true,
+        },
+    );
+
+    assert.deepEqual(
+        buildAuthFeedbackState({
+            errorMessage: 'Login failed. Please check your email and password.',
+        }),
+        {
+            state: 'error',
+            message: 'Login failed. Please check your email and password.',
+            role: 'alert',
+            ariaLive: 'assertive',
+            minHeight: 56,
+            showSpinner: false,
+        },
+    );
+
+    assert.deepEqual(
+        buildAuthFeedbackState({
+            successMessage: 'Signed in. Redirecting to your dashboard...',
+        }),
+        {
+            state: 'success',
+            message: 'Signed in. Redirecting to your dashboard...',
+            role: 'status',
+            ariaLive: 'polite',
+            minHeight: 56,
+            showSpinner: false,
+        },
+    );
+
+    assert.deepEqual(
+        buildAuthFeedbackState({
+            emptyMessage: 'Ready to sign in.',
+        }),
+        {
+            state: 'empty',
+            message: 'Ready to sign in.',
+            role: 'status',
+            ariaLive: 'polite',
+            minHeight: 56,
+            showSpinner: false,
+        },
+    );
+});
+
+test('buildAuthFeedbackContainerStyles keeps login feedback visually distinct without layout shift', () => {
+    assert.deepEqual(buildAuthFeedbackContainerStyles('loading'), {
+        bgcolor: 'transparent',
+        border: '1px solid transparent',
+    });
+
+    assert.deepEqual(buildAuthFeedbackContainerStyles('empty'), {
+        bgcolor: 'transparent',
+        border: '1px solid transparent',
+    });
+
+    assert.deepEqual(buildAuthFeedbackContainerStyles('success'), {
+        bgcolor: 'rgba(76, 175, 80, 0.08)',
+        border: '1px solid rgba(76, 175, 80, 0.2)',
+    });
+
+    assert.deepEqual(buildAuthFeedbackContainerStyles('error'), {
+        bgcolor: 'rgba(244, 67, 54, 0.08)',
+        border: '1px solid rgba(244, 67, 54, 0.2)',
+    });
+});

--- a/plans/story-claims/story-0014.md
+++ b/plans/story-claims/story-0014.md
@@ -1,0 +1,5 @@
+storyId: story-0014
+runTimestamp: 2026-06-11T17:16:37Z
+model: gpt-5
+plannedTestCommand: npm --prefix frontend run test:unit
+branch: codex/story-0014-login-recovery-operator-feedback-20260611-2


### PR DESCRIPTION
Adds a shared auth feedback surface helper, updates the login/signup feedback panels to show distinct success and error treatment, and adds a regression test for login operator feedback states.

Validation:
- `npm --prefix frontend run test:unit`
- `npm --prefix frontend run typecheck`
- `PYTHONPYCACHEPREFIX=/tmp/fine-dining-pyc python3 -m compileall backend`

Local board state was updated to `done` with verification noted in `plans/story-board.jsonl`.